### PR TITLE
Exclude migrations in workflow

### DIFF
--- a/.github/workflows/lint-python.yaml
+++ b/.github/workflows/lint-python.yaml
@@ -14,9 +14,9 @@ jobs:
       - name: Lint Python code
         run: |
           dirs="SORT home survey invites"
-          isort $dirs
-          black $dirs
-          flake8 $dirs
+          isort $dirs --skip-glob '*/migrations/*'
+          black $dirs --exclude '/migrations/'
+          flake8 $dirs --exclude '*/migrations/*'
       # Suggest merging any changes
       - name: Create Pull Request
         # https://github.com/marketplace/actions/create-pull-request


### PR DESCRIPTION
- Fixes issue #45 by including an `--exclude` flag in workflow file to avoid linting the `/migrations` folders in each app.