### PR TITLE
Remove `invite` URL config

### DIFF
--- a/SORT/urls.py
+++ b/SORT/urls.py
@@ -22,7 +22,6 @@ from django.urls import include, path
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("", include("home.urls")),
-    path("invite/", include("invites.urls"), name="invites"),
     path("", include("survey.urls"), name="survey"),
 ]
 


### PR DESCRIPTION
See issue #68 

Changes:
- Fix module not found error for `invites`
- Removed redundant invites import from the main URLconf file