### PR TITLE
Makefile for Easier Development

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,10 @@
 # https://flake8.pycqa.org/en/latest/user/configuration.html
 [flake8]
+exclude =
+    .git,
+    __pycache__,
+    migrations,
+    settings.py,
+    venv,
+    env
 max-line-length = 120

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,66 @@
+# Custom Django Development Makefile
+# This Makefile contains common Django management commands for easier development
+
+# Variables
+PYTHON = python
+MANAGE = $(PYTHON) manage.py
+PROJECT_NAME = SORT
+
+# Help command to list all available commands
+help:
+	@echo "Available commands:"
+	@echo "  make runserver        - Start Django development server"
+	@echo "  make migrations       - Create new database migrations"
+	@echo "  make migrate          - Apply database migrations"
+	@echo "  make superuser       - Create a superuser account"
+	@echo "  make static          - Collect static files"
+	@echo "  make shell           - Open Django shell"
+	@echo "  make test            - Run tests"
+	@echo "  make clean           - Remove Python compiled files"
+	@echo "  make requirements    - Install Python dependencies"
+	@echo "  make lint            - Run code linting on project files"
+
+# Development server
+runserver:
+	$(MANAGE) runserver
+
+# Database operations
+migrations:
+	$(MANAGE) makemigrations
+
+migrate:
+	$(MANAGE) migrate
+
+# User management
+superuser:
+	$(MANAGE) createsuperuser
+
+# Static files
+static:
+	$(MANAGE) collectstatic --noinput
+
+# Development tools
+shell:
+	$(MANAGE) shell
+
+test:
+	$(MANAGE) test
+
+clean:
+	find . -type f -name "*.pyc" -delete
+	find . -type d -name "__pycache__" -delete
+
+# Dependencies
+requirements:
+	pip install -r requirements.txt
+
+# Code quality - only check project source files
+lint:
+	flake8 $(PROJECT_NAME) --exclude=migrations,settings.py
+	black $(PROJECT_NAME) --exclude="migrations|settings.py"
+
+# Default target when just running 'make'
+.DEFAULT_GOAL := help
+
+# Mark these targets as always needing to run (not files)
+.PHONY: help runserver migrations migrate superuser static shell test clean requirements lint


### PR DESCRIPTION
I've been using a Makefile for my local development and thought others would benefit from this too:

- Example: instead of explicitly writing `python manage.py runserver` this is replaced by `make runserver`
- Other local development include running the test suite, cleaning cached files, and lining (see screenshots below)
- Updated `.flake8` to ignore cached files, site-packages, virtual environments, etc.

![image](https://github.com/user-attachments/assets/314f41d0-00f9-451c-b624-eb9b8c6808c6)
![image](https://github.com/user-attachments/assets/287b89c3-8458-4688-af42-bde50462a715)
