### PR TITLE
Survey invitation tokens and links

### DIFF
--- a/assets/sort-survey-configurator/vite.config.ts
+++ b/assets/sort-survey-configurator/vite.config.ts
@@ -16,9 +16,7 @@ export default defineConfig({
         sort_survey_cd: "./src/survey_config_consent_demography.ts",
         sort_survey_response: "./src/survey_response.ts"
       },
-      // single
       output: {
-        // format: "umd",
         chunkFileNames: `[name].[hash].js`,
         entryFileNames: "[name].js",
         dir: "../../static/js/sort-ui",

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = SORT.settings
+# -- recommended but optional:
+python_files = tests.py test_*.py *_tests.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,5 @@ wcwidth==0.2.13
 django_debug_toolbar==4.4.6
 gunicorn==23.*
 strenum==0.4.15
+pytest==8.3.4
+pytest-django==4.9.0

--- a/static/templates/base.html
+++ b/static/templates/base.html
@@ -36,9 +36,6 @@
                             <a class="nav-link {% if request.path == invite_url %}active{% endif %}" href="{{ home_url }}">Home</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link {% if '/invite' in request.path %}active{% endif %}" href="{% url 'invite' %}">Manage</a>
-                        </li>
-                        <li class="nav-item">
                             <a class="nav-link {% if '/profile' in request.path %}active{% endif %}" href="{% url 'profile' %}">Profile</a>
                         </li>
                         <li class="nav-item">

--- a/survey/admin.py
+++ b/survey/admin.py
@@ -1,5 +1,15 @@
 from django.contrib import admin
-from .models import Survey, SurveyResponse
+from .models import Survey, SurveyResponse, Invitation
+
+class InvitationAdmin(admin.ModelAdmin):
+    list_display = ("survey", "token", "created_at", "used")
+    search_fields = ("token",)
+    ordering = ("created_at",)
 
 admin.site.register(Survey)
 admin.site.register(SurveyResponse)
+admin.site.register(Invitation, InvitationAdmin)
+
+
+
+

--- a/survey/models.py
+++ b/survey/models.py
@@ -1,5 +1,7 @@
 import secrets
 from django.db import models
+from django.db.utils import IntegrityError
+from django.http import HttpRequest
 from django.urls import reverse
 from django.utils import timezone
 from home.models import Project
@@ -21,6 +23,21 @@ class Survey(models.Model):
     def get_absolute_url(self):
         return reverse("survey", kwargs={"pk": self.pk})
 
+    def current_invite_token(self):
+        for invite in self.invitation_set.all():
+            if not invite.is_expired() and not invite.used:
+                return invite.token
+        return None
+
+    def get_invite_link(self, request: HttpRequest):
+        token = self.current_invite_token()
+        if token is not None:
+            return request.build_absolute_uri("/survey_response/"+token)
+
+        return None
+
+
+
 
 class SurveyResponse(models.Model):
     """
@@ -31,7 +48,8 @@ class SurveyResponse(models.Model):
     answers = models.JSONField()
 
     def get_absolute_url(self, token):
-        return reverse('survey', kwargs={'pk': self.pk, 'token': token})
+        return reverse('survey', kwargs={"pk": self.survey.pk})
+
 
 
 
@@ -46,9 +64,20 @@ class Invitation(models.Model):
         return f"Invitation for {self.survey.name}"
 
     def save(self, *args, **kwargs):
+
         if not self.token:
-            self.token = secrets.token_urlsafe(32)
+            # Try a new token until it doesn't clash with an existing one
+            num_token_tries = 0
+            max_token_tries = 50
+            while num_token_tries < max_token_tries:
+                token = secrets.token_urlsafe(32)
+                if Invitation.objects.filter(token=token).count() < 1:
+                    self.token = token
+                    break
+                num_token_tries += 1
+
         super().save(*args, **kwargs)
 
     def is_expired(self):
         return timezone.now() > self.created_at + timezone.timedelta(days=7)
+

--- a/survey/services/__init__.py
+++ b/survey/services/__init__.py
@@ -1,0 +1,8 @@
+from .survey import SurveyService
+
+survey_service = SurveyService()
+
+__all__ = [
+    'SurveyService',
+    'survey_service',
+]

--- a/survey/services/survey.py
+++ b/survey/services/survey.py
@@ -1,8 +1,18 @@
+import json
 from typing import Any
 
-from home.services import BasePermissionService
-from home.models import User
+from django.shortcuts import get_object_or_404
 
+from home.services import BasePermissionService
+from home.models import User, Project
+from home.services.base import requires_permission
+from survey.models import Invitation, Survey, SurveyResponse
+
+import logging
+logger = logging.getLogger(__name__)
+
+class InvalidInviteTokenException(Exception):
+    pass
 
 class SurveyService(BasePermissionService):
 
@@ -16,3 +26,79 @@ class SurveyService(BasePermissionService):
         return True
     def can_delete(self, user: User, instance: Any) -> bool:
         return True
+
+
+    def get_survey(self, survey_id: int) -> Survey:
+        survey = get_object_or_404(Survey, pk=survey_id)
+        return survey
+
+
+    def create_survey(self, survey: Survey, project: Project) -> Survey:
+        survey.project = project
+
+        # TODO: Make a proper loader function
+        with open("data/survey_config/consent_only_config.json") as f:
+            consent_config = json.load(f)
+            survey.consent_config = consent_config
+
+        with open("data/survey_config/demography_only_config.json") as f:
+            demo_config = json.load(f)
+            survey.demography_config = demo_config
+
+        survey.survey_config = {}
+        survey.save()
+
+        return survey
+
+    def update_consent_demography_config(self,
+                                         survey: Survey,
+                                         consent_config,
+                                         demography_config) -> Survey:
+        survey.consent_config = consent_config
+        survey.demography_config = demography_config
+
+        with open("data/survey_config/sort_only_config.json") as f:
+            sort_config = json.load(f)
+            merged_sections = survey.consent_config["sections"] + sort_config["sections"] + survey.demography_config[
+                "sections"]
+            survey.survey_config = {
+                "sections": merged_sections
+            }
+        survey.save()
+        return survey
+
+    def get_survey_from_token(self, token: str) -> Survey:
+        invitations = Invitation.objects.filter(token=token)
+
+        # Checks that token is valid
+        if not invitations.exists():
+            logger.warning("Trying to get token that does not exist")
+            raise InvalidInviteTokenException("Token does not exist")
+
+        invitation = invitations.first()
+        if invitation.used is True:
+            logger.warning("Trying to use an invalid token")
+            raise InvalidInviteTokenException("Token is invalid")
+
+        return invitation.survey
+
+
+
+    def accept_response(self, survey: Survey, responseValues):
+        SurveyResponse.objects.create(survey=survey, answers=responseValues)
+
+
+
+    def create_invitation(self, survey: Survey) -> Invitation:
+
+        # Invalidate all other invite tokens
+        for invite in survey.invitation_set.all():
+            invite.used = True
+            invite.save()
+
+        # Add new invite token
+        return Invitation.objects.create(survey=survey)
+
+
+
+

--- a/survey/templates/survey/survey.html
+++ b/survey/templates/survey/survey.html
@@ -32,16 +32,40 @@
 
                 <div class="mb-3 mt-3">
                     <h3>Invite your participants</h3>
-                    <p>Invite your participants using the follow link</p>
-                    <ul>
-                        <li>
-                            <a href="{% url "invite" %}">Send an invitation</a>
-                        </li>
-                        <li>
-                            Link to fill in survey <a
-                                href="{% url 'survey_response' survey.id 'notoken' %}">{% url 'survey_response' survey.id 'notoken' %}</a>
-                        </li>
-                    </ul>
+
+                    {% if invite_link %}
+                        <p>Invite your participants using the follow link:</p>
+                        <form method="post" action="{% url 'suvey_create_invite' survey.id %}">
+                            <div class="input-group mb-3">
+                            <span class="input-group-text">
+                                Invitation link
+                            </span>
+                                {% csrf_token %}
+                                <input type="text" class="form-control" disabled value="{{ invite_link }}"/>
+                                <input type="submit" class="btn btn-outline-primary" name="generate_token"
+                                       value="Regenerate invitation"/>
+
+                            </div>
+                        </form>
+
+                        <p>Or send an invitation by email:</p>
+
+                        <a href="{% url 'invite' survey.id %}" class="btn btn-primary">Send an invitation</a>
+
+                    {% else %}
+                        <p>
+                            Geneate an invitation link for your participants to fill in the survey:
+                        </p>
+                        <form method="post" action="{% url 'suvey_create_invite' survey.id %}">
+                            {% csrf_token %}
+                            <input type="submit" name="generate_token" value="Generate invitation"
+                                   class="btn btn-primary"/>
+                        </form>
+
+
+                    {% endif %}
+
+
                 </div>
 
             </div>

--- a/survey/templates/survey/survey.html
+++ b/survey/templates/survey/survey.html
@@ -35,18 +35,46 @@
 
                     {% if invite_link %}
                         <p>Invite your participants using the follow link:</p>
-                        <form method="post" action="{% url 'suvey_create_invite' survey.id %}">
-                            <div class="input-group mb-3">
-                            <span class="input-group-text">
-                                Invitation link
-                            </span>
-                                {% csrf_token %}
-                                <input type="text" class="form-control" disabled value="{{ invite_link }}"/>
-                                <input type="submit" class="btn btn-outline-primary" name="generate_token"
-                                       value="Regenerate invitation"/>
+
+
+                        <div class="row">
+                            <div class="col-lg-10">
+                                <div class="input-group mb-3">
+                                    <div class="input-group-prepend">
+                                        <span class="input-group-text">Invitation link</span>
+                                    </div>
+                                    <input type="text" id="invitation_link" class="form-control" disabled
+                                           value="{{ invite_link }}"/>
+                                    <div class="input-group-append">
+                                        <button class="btn btn-primary" type="button"
+                                                onclick="copyInviteLink()"><i
+                                                class='bx bx-clipboard'></i> <span id="copyBtnText">Copy</span>
+                                        </button>
+                                    </div>
+                                </div>
+
+                                <script>
+                                  function copyInviteLink() {
+                                    let copyBtnTextElem = document.getElementById("copyBtnText");
+                                    let link = document.getElementById("invitation_link").value;
+                                    navigator.clipboard.writeText(link);
+                                    copyBtnTextElem.innerHTML = "Copied";
+                                    setTimeout(()=>{
+                                      copyBtnTextElem.innerHTML = "Copy";
+                                    }, 2000);
+                                  }
+                                </script>
 
                             </div>
-                        </form>
+                            <div class="col-lg-2 text-end">
+                                <form method="POST" action="{% url 'suvey_create_invite' survey.id %}">
+                                    {% csrf_token %}
+                                    <input type="submit" class="btn btn-primary" name="generate_token"
+                                           value="Regenerate invitation"/>
+                                </form>
+                            </div>
+                        </div>
+
 
                         <p>Or send an invitation by email:</p>
 

--- a/survey/templates/survey/survey_link_invalid_view.html
+++ b/survey/templates/survey/survey_link_invalid_view.html
@@ -1,8 +1,11 @@
 {% extends 'base.html' %}
 
 {% block content %}
+    <div class="container mb-3">
+        <h3>Your survey link is invalid</h3>
+        <p>Reason ... e.g. token expired, no longer accepting responses,etc.</p>
+    </div>
 
-    <h3>Your survey link is invalid</h3>
-    <p>Reason ... e.g. token expired, no longer accepting responses,etc.</p>
+
 
 {% endblock %}

--- a/survey/tests.py
+++ b/survey/tests.py
@@ -1,3 +1,5 @@
-# from django.test import TestCase
+from django.test import TestCase
+from .models import Survey, Invitation
 
 # Create your tests here.
+

--- a/survey/urls.py
+++ b/survey/urls.py
@@ -3,11 +3,13 @@ from . import views
 urlpatterns = [
     path('survey/<int:pk>', views.SurveyView.as_view(), name='survey'),
     path('survey/<int:pk>/configure', views.SurveyConfigureView.as_view(), name='survey_configure'),
+    path('survey/<int:pk>/create_invite', views.SurveyCreateInviteView.as_view(), name='suvey_create_invite'),
+
     path('survey/create/<int:project_id>', views.SurveyCreateView.as_view(), name='survey_create'),
     path('completion/', views.CompletionView.as_view(), name='completion_page'),
-    path('survey_response/<int:pk>/<str:token>', views.SurveyResponseView.as_view(), name='survey_response'),
+    path('survey_response/<str:token>', views.SurveyResponseView.as_view(), name='survey_response'),
     path('survey_link_invalid/', views.SurveyLinkInvalidView.as_view(), name='survey_link_invalid'),
-    path('invite/', views.InvitationView.as_view(), name='invite'),
+    path('invite/<int:pk>', views.InvitationView.as_view(), name='invite'),
     path('invite/success/', views.SuccessInvitationView.as_view(), name='success_invitation'),
 
 ]

--- a/survey/views.py
+++ b/survey/views.py
@@ -1,8 +1,9 @@
 import json
+from multiprocessing.managers import Token
 
 from IPython.utils.coloransi import value
 from django.core.mail import send_mail
-from django.http import HttpRequest
+from django.http import HttpRequest, Http404
 from django.shortcuts import render, get_object_or_404, redirect
 from django.urls import reverse_lazy
 from django.utils.functional import unpickle_lazyobject
@@ -13,6 +14,7 @@ from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.template.context_processors import csrf
 from home.models import Project
+from survey.services import survey_service
 from .mixins import TokenAuthenticationMixin
 
 from .forms import create_dynamic_formset, InvitationForm
@@ -21,6 +23,8 @@ from .models import Invitation
 from .misc import test_survey_config
 
 import logging
+
+from .services.survey import InvalidInviteTokenException
 
 logger = logging.getLogger(__name__)
 
@@ -32,17 +36,17 @@ class SurveyView(LoginRequiredMixin, View):
     """
     login_url = '/login/'  # redirect to login if not authenticated
 
-    def get(self, request, pk):
+    def get(self, request: HttpRequest, pk: int):
         return self.render_survey_page(request, pk)
 
-    def post(self, request, pk):
-        return self.render_survey_page(request, pk)
+    def post(self, request: HttpRequest, pk: int):
+        return self.render_survey_page(request, pk, is_post=True)
 
-    def render_survey_page(self, request, pk):
+    def render_survey_page(self, request: HttpRequest, pk: int, is_post=False):
         context = {}
-        survey = get_object_or_404(Survey, pk=pk)
-
+        survey = survey_service.get_survey(survey_id=pk)
         context["survey"] = survey
+        context["invite_link"] = survey.get_invite_link(request)
 
         return render(request, 'survey/survey.html', context)
 
@@ -51,36 +55,26 @@ class SurveyCreateView(LoginRequiredMixin, CreateView):
     model = Survey
     template_name = "survey/create.html"
     fields = ["name", "description"]
+    login_url = '/login/'
 
     def get_success_url(self):
         return self.object.get_absolute_url()
 
     def form_valid(self, form):
         result = super().form_valid(form)
-        project = Project.objects.get(id=self.kwargs["project_id"])
-        self.object.project = project
-
-        # TODO: Make a proper loader function
-        with open("data/survey_config/consent_only_config.json") as f:
-            consent_config = json.load(f)
-            self.object.consent_config = consent_config
-
-        with open("data/survey_config/demography_only_config.json") as f:
-            demo_config = json.load(f)
-            self.object.demography_config = demo_config
-
-        self.object.survey_config = test_survey_config  # TODO: Using a test config for now, to be replaced
-        self.object.save()
+        project = Project.objects.get(pk=self.kwargs["project_id"])
+        survey_service.create_survey(self.object, project)
         return result
 
 
 class SurveyConfigureView(LoginRequiredMixin, View):
+    login_url = '/login/'
 
     def get(self, request: HttpRequest, pk: int):
         return self.render_survey_config_view(request, pk, is_post=False)
 
     def post(self, request: HttpRequest, pk: int):
-        return self.render_survey_config_view(request, pk,  is_post=True)
+        return self.render_survey_config_view(request, pk, is_post=True)
 
     def render_survey_config_view(self, request: HttpRequest, pk: int, is_post: bool):
         context = {}
@@ -89,18 +83,12 @@ class SurveyConfigureView(LoginRequiredMixin, View):
         context["survey"] = survey
         context["csrf"] = str(csrf(self.request)["csrf_token"])
 
-
         if is_post:
             if "consent_config" in request.POST and "demography_config" in request.POST:
-                survey.consent_config = json.loads(request.POST["consent_config"])
-                survey.demography_config = json.loads(request.POST["demography_config"])
-                with open("data/survey_config/sort_only_config.json") as f:
-                    sort_config = json.load(f)
-                    merged_sections = survey.consent_config["sections"] + sort_config["sections"] + survey.demography_config["sections"]
-                    survey.survey_config = {
-                        "sections": merged_sections
-                    }
-                survey.save()
+                consent_config = json.loads(request.POST.get("consent_config", None))
+                demography_config = json.loads(request.POST.get("demography_config", None))
+                survey_service.update_consent_demography_config(survey, consent_config, demography_config)
+                # TODO: Return success message
 
         return render(request=request,
                       template_name="survey/survey_configure.html",
@@ -114,66 +102,42 @@ class SurveyResponseView(View):
     allowing participant to fill in the survey form and send it for processing.
     """
 
-    def get(self, request: HttpRequest, pk: int, token: str):
-        return self.render_survey_response_page(request, pk, token, is_post=False)
+    def get(self, request: HttpRequest, token: str):
+        return self.render_survey_response_page(request, token, is_post=False)
 
-    def post(self, request: HttpRequest, pk: int, token: str):
-        return self.render_survey_response_page(request, pk, token, is_post=True)
+    def post(self, request: HttpRequest, token: str):
+        return self.render_survey_response_page(request, token, is_post=True)
 
     def render_survey_response_page(self,
                                     request: HttpRequest,
-                                    pk: int,
                                     token: str,
                                     is_post: bool):
 
+        try:
 
+            survey = survey_service.get_survey_from_token(token)
+            # Context for rendering
+            context = {}
 
-        # Check token
+            if is_post:
+                # Only process if it's a post request
 
-        # TODO: Re-enable token once the invitation UI is in place
-        # if not self.validate_token(token):
-        #     messages.error(request, "Invalid or expired invitation token.")
-        #     logger.error(f"Token validation failed.")
-        #     return redirect('survey_link_invalid')
+                # TODO: Server side value validation to make sure
+                if "value" in request.POST:
+                    responseValues = json.loads(request.POST.get("value", None))
+                    survey_service.accept_response(survey, responseValues)
+                    context["value"] = responseValues
+                    return redirect("completion_page")
 
-        # Get the survey object and config
-        survey = get_object_or_404(Survey, pk=pk)
-        survey_config = survey.survey_config
+            context["survey"] = survey
+            context["csrf"] = str(csrf(self.request)["csrf_token"])
 
-        # TODO: Check that config is valid
+            return render(request=request,
+                          template_name='survey/survey_response.html',
+                          context=context)
 
-        # Context for rendering
-        context = {}
-
-        context["pk"] = pk
-        context["token"] = token
-
-        if is_post:
-            # TODO: Server side value validation to make sure
-            # Only process if it's a post request
-            if "value" in request.POST:
-                responseValues = json.loads(request.POST.get("value",None))
-                context["value"] = responseValues
-                SurveyResponse.objects.create(survey=survey, answers=responseValues)
-
-
-
-        context["survey"] = survey
-        context["csrf"] = str(csrf(self.request)["csrf_token"])
-
-        return render(request=request,
-                      template_name='survey/survey_response.html',
-                      context=context)
-
-    def validate_token(self, token):
-
-        is_valid = Invitation.objects.filter(token=token).exists()
-
-        if is_valid:
-            logger.info("Token is valid.")
-        else:
-            logger.warning("Token is invalid or expired.")
-        return is_valid
+        except InvalidInviteTokenException as e:
+            return redirect('survey_link_invalid')
 
 
 class SurveyLinkInvalidView(View):
@@ -196,22 +160,26 @@ class CompletionView(View):
         return render(request, "survey/completion.html")
 
 
+class SurveyCreateInviteView(LoginRequiredMixin, View):
+    login_url = '/login/'
+
+    def post(self, request: HttpRequest, pk: int):
+        survey = get_object_or_404(Survey, pk=pk)
+        survey_service.create_invitation(survey)
+        return redirect("survey", pk=pk)
+
+
 class InvitationView(FormView):
+    model = Survey
     template_name = 'invitations/send_invitation.html'
     form_class = InvitationForm
     success_url = reverse_lazy('success_invitation')
 
     def form_valid(self, form):
         email = form.cleaned_data['email']
-
-        survey = Survey.objects.first()
-
-        invitation = Invitation.objects.create(survey=survey)
-
-        token = invitation.token
-
+        survey = Survey.objects.get(pk=self.kwargs["pk"])
         # Generate the survey link with the token
-        survey_link = f"http://localhost:8000/survey/{survey.pk}/{token}/"
+        survey_link = survey.get_invite_link()
 
         # Send the email
         send_mail(


### PR DESCRIPTION
Depends on #83 , make sure that's been reviewd merged in first and I'll rebase this branch to dev

- `SurveyResponseView` endpoint no longer needs the ID, this is inferred from the provided token
- Tokens can now be generated and re-generated from the UI
- Removed the`Manage` page in the top nav bar, a button for sending invitations by email now links to this page
- Add `SurveyService` for handling business/db logic (apart from get and filter as django model views also fetches the object first for you), moved the code from the views to the service.

Before there's a valid associated token:
![image](https://github.com/user-attachments/assets/adc36b5d-a5ba-4fae-b0dc-2fba3be65f85)

When a valid token exists:
![image](https://github.com/user-attachments/assets/835bcbf4-705d-44bd-8d42-d7a1bcce21bc)
