### PR TITLE
feat: add report page

### DIFF
--- a/survey/templates/survey/report.html
+++ b/survey/templates/survey/report.html
@@ -1,0 +1,24 @@
+{% extends 'base_anonymous.html' %}
+{% load plotly_dash %}
+{% block content %}
+{#<div class="mt-3 mb-3">#}
+{#    <button class="btn btn-primary" onclick="generatePDF()">Download PDF</button>#}
+{#</div>#}
+<div id="report-page">
+    <div class="p-2">
+        <h1>Survey Report: {{ survey.name }}</h1>
+    </div>
+    <div style="width: 100%; padding: 20px; text-align: center;">
+        {% plotly_direct name="SurveyDashboard" %}
+    </div>
+</div>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js" integrity="sha512-GsLlZN/3F2ErC5ifS5QtgpiJtWd43JWSuIgh7mbzZ8zBps+dvLusV+eNQATqgA/HdeKFVgA5v3S/cIrLF7QnIg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script>
+    function generatePDF(){
+      console.log("Trying to generate pdf");
+        let element = document.getElementById('report-page');
+        html2pdf(element);
+    }
+</script>
+
+{% endblock %}

--- a/survey/templates/survey/survey.html
+++ b/survey/templates/survey/survey.html
@@ -38,7 +38,7 @@
         </div>
 
         <div class="mb-3">
-            You can follow the five steps below to carry out the survey:
+            You can follow the six steps below to carry out the survey:
         </div>
 
         <div class="card mb-3">
@@ -165,7 +165,7 @@
             <div class="card-body"
                  style="display: flex; justify-content: center; align-items: center; flex-direction: column; ">
                 {% if has_responses %}
-                    <div style="width: 100%; padding: 20px; text-align: center;>
+                    <div style="width: 100%; padding: 20px; text-align: center;">
                         {% plotly_direct name="SurveyDashboard" %}
                     </div>
                 {% else %}
@@ -186,4 +186,19 @@
                     <h2>5. Make an Improvement Plan</h2>
                 </div>
             </div>
+
+            <div class="card mb-3">
+                <div class="card-header">
+                    <h2>6. Report and data export</h2>
+                </div>
+                <div class="card-body">
+                    <p>You can generate a printable report of this survey or export survey data to a spreadsheet format here.</p>
+                    <div class="d-flex mt-3 mb-3">
+                        <a href="{% url 'survey_report' survey.id %}" class="btn btn-primary me-3">View report</a>
+                        <a href="{% url 'survey_report' survey.id %}" class="btn btn-primary">Export spreadsheet data</a>
+                    </div>
+                </div>
+            </div>
+
+    </div>
 {% endblock %}

--- a/survey/urls.py
+++ b/survey/urls.py
@@ -8,6 +8,7 @@ urlpatterns = [
     path('survey/<int:pk>/delete/', views.SurveyDeleteView.as_view(), name='survey_delete'),
     path('survey/<int:pk>/create_invite', views.SurveyCreateInviteView.as_view(), name='suvey_create_invite'),
     path('survey/<int:pk>/mock_responses', views.SurveyGenerateMockResponsesView.as_view(), name='survey_mock_responses'),
+    path('survey/<int:pk>/report', views.SurveyReportView.as_view(), name='survey_report'),
     path('survey/create/<int:project_id>', views.SurveyCreateView.as_view(), name='survey_create'),
     path('completion/', views.CompletionView.as_view(), name='completion_page'),
     path('survey_response/<str:token>', views.SurveyResponseView.as_view(), name='survey_response'),

--- a/survey/views.py
+++ b/survey/views.py
@@ -171,6 +171,11 @@ class SurveyGenerateMockResponsesView(LoginRequiredMixin, View):
 
         return redirect("survey", pk=pk)
 
+class SurveyReportView(View):
+    def get(self, request: HttpRequest, pk: int):
+        survey = get_object_or_404(Survey, pk=pk)
+        context = {"survey": survey}
+        return render(request=request, template_name="survey/report.html", context=context)
 
 # TODO: Add TokenAuthenticationMixin after re-enabling the token
 class SurveyResponseView(View):


### PR DESCRIPTION
- Add report page
  - I've tried using a pdf exporter (html2pdf) but it doesn't look very good (see link below). There needs to be a bit of a tweak to how the stats are rendered but I don't want to mess too much with your templates as you're still working on it. I think it's ok to open up a link to a printable page and have them print a report to pdf for now.
- Add new section on survey page linking to report (also export csv implemented in #131 )
[file-2.pdf](https://github.com/user-attachments/files/18783270/file-2.pdf)
