### PR TITLE
ui/fix survey pages accessibility

### DIFF
--- a/assets/sort-survey-configurator/src/lib/components/input/Likert.svelte
+++ b/assets/sort-survey-configurator/src/lib/components/input/Likert.svelte
@@ -42,7 +42,7 @@
     <table class="table table-striped" style="width: 100%;">
         <thead>
         <tr>
-            <th></th>
+            <th>Statement</th>
             {#each config.options as option}
                 <th scope="col">{option}</th>
             {/each}

--- a/assets/sort-survey-configurator/src/lib/components/input/LikertRow.svelte
+++ b/assets/sort-survey-configurator/src/lib/components/input/LikertRow.svelte
@@ -35,6 +35,7 @@
                    value={option}
                    bind:group={value}
                    required={config.required}
+                   placeholder={option}
             />
         </div>
     </td>

--- a/assets/sort-survey-configurator/src/lib/components/input/Radio.svelte
+++ b/assets/sort-survey-configurator/src/lib/components/input/Radio.svelte
@@ -33,7 +33,8 @@
             <input class={{"form-check-input": true, "is-valid": isValid, "is-invalid": isInvalid}}
                    type="radio"
                    value={option} id={componentId[index]}
-                   bind:group={value} />
+                   bind:group={value}
+                   placeholder={option} />
             <label class="form-check-label" for="{componentId[index]}">{option}</label>
             {#if config.options && index >= config.options.length - 1}
             <!-- Feedback on the last component only -->

--- a/survey/templates/survey/survey.html
+++ b/survey/templates/survey/survey.html
@@ -134,8 +134,7 @@
                     </p>
                     <form method="post" action="{% url 'suvey_create_invite' survey.id %}">
                         {% csrf_token %}
-                        <input type="submit" name="generate_token" value="Generate invitation"
-                               class="btn btn-primary"></input>
+                        <button type="submit" class="btn btn-primary" name="generate_token"><i class='bx bx-mail-send' ></i> Generate invitation</button>
                     </form>
                 {% endif %}
             </div>


### PR DESCRIPTION
Closes #77 

Fixing accessibility errors on survey pages
- added "Statement" to empty table header 
- added `placeholder={option}` as a label for radio buttons
- these will need to be checked by someone who can regenerate the svelte files 

Also
- added icon for "Generate invitation" button

Questions
- I'm unable to see the icon for "Save" button in configure survey, I have previously added it on this line (https://github.com/RSE-Sheffield/SORT/blob/8467ccb13a1484114167db9a2f530d24d21217a9/assets/sort-survey-configurator/src/SurveyConfigConsentDemographyApp.svelte#L60) but for some reason it doesn't display and I'm not sure why, I can't seem to rebuild the svelte files
- The survey pages require a level one heading for accessibility, `<h1>` , but haven't been able to work out how to add this. I wanted to add it to the survey section titles, `sections.title`