### PR TITLE
Fix the Gunicorn config checker

### DIFF
--- a/.github/workflows/check-gunicorn-config.yaml
+++ b/.github/workflows/check-gunicorn-config.yaml
@@ -10,7 +10,10 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v5.3.0
+        with:
+          python-version: "3.12"
+          cache: "pip"
       - name: Install Gunicorn
-        run: pip install gunicorn
+        run: pip install gunicorn django
       - name: Check Gunicorn config
         run: gunicorn --config ./gunicorn.conf.py --check-config SORT.wsgi:application


### PR DESCRIPTION
Install Django package to fix `ModuleNotFoundError: No module named 'django'`