### PR TITLE
JS optimisation and improve vite integration

### DIFF
--- a/SORT/settings.py
+++ b/SORT/settings.py
@@ -188,7 +188,7 @@ AUTH_USER_MODEL = "home.User"  # FA: replace username with email as unique ident
 # Vite integration
 VITE_BASE_URL = "http://localhost:5173" # Url of vite dev server
 VITE_STATIC_DIR= "ui-components" # Path to vite-generated asset directory in the static folder
-VITE_MANIFEST_FILE_PATH = os.path.join(VITE_STATIC_DIR, ".vite/manifest.json")
+VITE_MANIFEST_FILE_PATH = os.path.join(VITE_STATIC_DIR, "manifest.json")
 
 # FA: for production:
 

--- a/home/templatetags/vite_integration.py
+++ b/home/templatetags/vite_integration.py
@@ -1,15 +1,22 @@
 import json
 import logging
+from enum import Enum
 from os import path
+from typing import LiteralString
+
 from django import template
 from urllib.parse import urljoin
 from django.conf import settings
 from django.utils.safestring import mark_safe
 from django.contrib.staticfiles import finders
-from django.templatetags.static import  static
+from django.templatetags.static import static
+
 logger = logging.getLogger(__name__)
 
 register = template.Library()
+
+VITE_MANIFEST = None
+
 
 @register.simple_tag
 def vite_client():
@@ -23,6 +30,9 @@ def vite_client():
     return ""
 
 
+class AssetType(Enum):
+    SCRIPT = 0
+    CSS = 1
 
 
 @register.simple_tag
@@ -35,18 +45,40 @@ def vite_asset(asset_path):
         vite_asset_path = urljoin(settings.VITE_BASE_URL, asset_path)
         return mark_safe(f"<script type = 'module' src = '{vite_asset_path}' > </script>")
     else:
-        vite_manifest_path = finders.find(settings.VITE_MANIFEST_FILE_PATH)
-        if vite_manifest_path:
-            with open(vite_manifest_path, "r") as f:
-                vite_manifest = json.load(f)
-                if asset_path in vite_manifest:
-                    asset_static_path = path.join(settings.VITE_STATIC_DIR, vite_manifest[asset_path]["file"])
-                    asset_static_path_found = finders.find(asset_static_path)
-                    if asset_static_path_found:
-                        return mark_safe(f"<script type = 'module' src = '{static(asset_static_path)}' > </script>")
-                    else:
-                        raise FileNotFoundError(f"Specified vite asset file {asset_static_path} cannot found.")
-        else:
-            raise FileNotFoundError(f"Vite manifest file ({settings.VITE_MANIFEST_FILE_PATH}) cannot be found.")
+        global VITE_MANIFEST
+        if VITE_MANIFEST is None:
+            vite_manifest_path = finders.find(settings.VITE_MANIFEST_FILE_PATH)
+            if vite_manifest_path:
+                with open(vite_manifest_path, "r") as f:
+                    VITE_MANIFEST = json.load(f)
+            else:
+                raise FileNotFoundError(f"Vite manifest file ({settings.VITE_MANIFEST_FILE_PATH}) cannot be found.")
+
+        if asset_path in VITE_MANIFEST:
+            manifest_asset = VITE_MANIFEST[asset_path]
+            import_tags = []
+            if "css" in manifest_asset:
+                for css_path in manifest_asset["css"]:
+                    import_tags.append(get_asset_import_tag(path.join(settings.VITE_STATIC_DIR, css_path),
+                                                            AssetType.CSS))
+
+            if "file" in manifest_asset:
+                import_tags.append(get_asset_import_tag(path.join(settings.VITE_STATIC_DIR, manifest_asset["file"]),
+                                                        AssetType.SCRIPT))
+
+            return mark_safe("".join(import_tags))
 
     return ""
+
+
+def get_asset_import_tag(asset_static_path: str | LiteralString | bytes, type: AssetType):
+    asset_static_path_found = finders.find(asset_static_path)
+    if asset_static_path_found:
+        if type == AssetType.SCRIPT:
+            return f"<script type = 'module' src = '{static(asset_static_path)}' ></script>\n"
+        elif type == AssetType.CSS:
+            return f"<link rel='stylesheet' href='{static(asset_static_path)}'>\n"
+        else:
+            return ""
+    else:
+        raise FileNotFoundError(f"Specified vite asset file {asset_static_path} cannot found.")

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,12 +15,14 @@
         "chart.js": "^4.4.8",
         "http-server": "^14.1.1",
         "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
         "quill": "^2.0.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.24.0",
         "@sveltejs/vite-plugin-svelte": "^5.0.3",
         "@tsconfig/svelte": "^5.0.4",
+        "@types/lodash-es": "^4.17.12",
         "eslint": "^9.24.0",
         "globals": "^16.0.0",
         "svelte": "^5.15.0",
@@ -1141,6 +1143,15 @@
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.16.tgz",
       "integrity": "sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==",
       "license": "MIT"
+    },
+    "node_modules/@types/lodash-es": {
+      "version": "4.17.12",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
+      "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.29.0",
@@ -2557,8 +2568,7 @@
     "node_modules/lodash-es": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-      "license": "MIT"
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@eslint/js": "^9.24.0",
     "@sveltejs/vite-plugin-svelte": "^5.0.3",
     "@tsconfig/svelte": "^5.0.4",
+    "@types/lodash-es": "^4.17.12",
     "eslint": "^9.24.0",
     "globals": "^16.0.0",
     "svelte": "^5.15.0",
@@ -31,6 +32,7 @@
     "chart.js": "^4.4.8",
     "http-server": "^14.1.1",
     "lodash": "^4.17.21",
+    "lodash-es": "^4.17.21",
     "quill": "^2.0.3"
   }
 }

--- a/survey/templates/survey/evidence_gathering.html
+++ b/survey/templates/survey/evidence_gathering.html
@@ -2,8 +2,6 @@
 {% load static %}
 {% load vite_integration %}
 {% block content %}
-    <!-- Include stylesheet -->
-    <link href="https://cdn.jsdelivr.net/npm/quill@2.0.3/dist/quill.snow.css" rel="stylesheet"/>
     <div class="container mx-auto px-4 py-8 mt-4">
         <nav aria-label="breadcrumb">
             <ol class="breadcrumb">

--- a/ui_components/src/App.svelte
+++ b/ui_components/src/App.svelte
@@ -3,7 +3,7 @@
     /**
      * Harness for testing SORT UI components
      */
-    import * as _ from 'lodash';
+    import * as _ from "lodash-es";
     import defaultConfigs from '../../../data/survey_config/all_elements_test_config.json';
     import SurveyConfigurator from "./lib/components/SurveyConfigurator.svelte";
     import SurveyResponse from "./lib/components/SurveyResponse.svelte";

--- a/ui_components/src/SurveyConfigConsentDemographyApp.svelte
+++ b/ui_components/src/SurveyConfigConsentDemographyApp.svelte
@@ -1,7 +1,4 @@
 <script lang="ts">
-    import * as _ from 'lodash';
-    // import defaultConsentConfigs from '../../../data/survey_config/consent_only_config.json';
-    // import defaultDemographicConfigs from '../../../data/survey_config/demography_only_config.json';
     import SurveyConfigurator from "./lib/components/SurveyConfigurator.svelte";
 
 

--- a/ui_components/src/SurveyResponseApp.svelte
+++ b/ui_components/src/SurveyResponseApp.svelte
@@ -1,9 +1,5 @@
 <script lang="ts">
-    import * as _ from 'lodash';
-    // import defaultConfigs from '../../../data/survey_config/sort_only_config.json';
-    import SurveyConfigurator from "./lib/components/SurveyConfigurator.svelte";
     import SurveyResponse from "./lib/components/SurveyResponse.svelte";
-    import {getDataInElem} from "./lib/misc.svelte.js";
 
     let {csrf, initConfig, initResponse} = $props();
 

--- a/ui_components/src/lib/components/QuillEditor.svelte
+++ b/ui_components/src/lib/components/QuillEditor.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import "quill/dist/quill.snow.css"
-    import Quill from "quill"
+    import Quill from "quill/core"
     import {onMount} from "svelte";
 
     let {csrf, updateUrl, initContents, viewOnly=false} = $props();

--- a/ui_components/src/lib/components/SmartTable.svelte
+++ b/ui_components/src/lib/components/SmartTable.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import * as _ from "lodash"
+    import * as _ from "lodash-es"
 
     interface ActionItem {
         currentPosition: string;

--- a/ui_components/src/lib/components/SortLikertStats.svelte
+++ b/ui_components/src/lib/components/SortLikertStats.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import * as _ from "lodash"
+    import * as _ from "lodash-es"
     import type {SurveyConfig, SurveyStats} from "../interfaces.ts";
     import LikertHistogram from "./graph/LikertHistogram.svelte";
     import {

--- a/ui_components/src/lib/components/SortSummaryMatrix.svelte
+++ b/ui_components/src/lib/components/SortSummaryMatrix.svelte
@@ -1,9 +1,6 @@
 <script lang="ts">
     import type {SurveyConfig, SurveyStats} from "../interfaces.ts";
     import {formatNumber, getColourForMeanValue, getTextColourForMeanValue} from "../misc.svelte.ts";
-
-
-
     interface Props {
         config: SurveyConfig;
         surveyStats: SurveyStats;

--- a/ui_components/src/lib/components/SurveyConfigurator.svelte
+++ b/ui_components/src/lib/components/SurveyConfigurator.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 
-    import * as _ from "lodash"
+    import * as _ from "lodash-es"
     import SectionComponent, {getDefaultSectionConfig} from "./input/SectionComponent.svelte";
 
     let {

--- a/ui_components/src/lib/components/SurveyResponse.svelte
+++ b/ui_components/src/lib/components/SurveyResponse.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import * as _ from "lodash"
+    import * as _ from "lodash-es"
     import SectionComponent from "./input/SectionComponent.svelte";
 
     let {

--- a/ui_components/src/lib/components/graph/LikertHistogram.svelte
+++ b/ui_components/src/lib/components/graph/LikertHistogram.svelte
@@ -1,26 +1,47 @@
 <script lang="ts">
-    import * as _ from "lodash";
+    import * as _ from "lodash-es";
     import {onMount} from "svelte";
-    import Chart from "chart.js/auto";
+    import {
+        Chart,
+        Colors,
+        BarController,
+        CategoryScale,
+        LinearScale,
+        BarElement,
+        Legend,
+        PointElement
+
+    } from 'chart.js'
+
+    Chart.register(
+        Colors,
+        BarController,
+        BarElement,
+        CategoryScale,
+        LinearScale,
+        Legend,
+        PointElement
+    );
     import type {FieldConfig, FieldStats} from "../../interfaces.ts";
     import {getColourForMeanValue, getHistogramMean} from "../../misc.svelte.js";
 
     type IndexMean = {
-        index:number;
+        index: number;
         mean: number;
     }
 
-    interface LikertHistogramProps{
+    interface LikertHistogramProps {
         fieldConfig: FieldConfig;
         fieldStats: FieldStats;
     }
+
     let {fieldConfig, fieldStats}: LikertHistogramProps = $props();
     let barChartContainer: HTMLCanvasElement = $state()
-    let chartHeight = $derived(fieldConfig.sublabels.length*5);
-    let chart: Chart|null = $state(null);
+    let chartHeight = $derived(fieldConfig.sublabels.length * 5);
+    let chart: Chart | null = $state(null);
     let sortByMean = $state(false);
     let sortAscending = $state(true);
-    let indexMean: IndexMean[] = $derived.by(()=>{
+    let indexMean: IndexMean[] = $derived.by(() => {
         let ims: IndexMean[] = [];
         fieldStats.histograms.map((value, index) => {
             ims.push({
@@ -29,28 +50,28 @@
             })
         });
 
-        if(sortByMean){
-            let sortOrder: (boolean |"asc"|"desc")[] = ["asc", "asc"];
-            if(!sortAscending) sortOrder = ["desc", "desc"];
+        if (sortByMean) {
+            let sortOrder: (boolean | "asc" | "desc")[] = ["asc", "asc"];
+            if (!sortAscending) sortOrder = ["desc", "desc"];
             ims = _.orderBy(ims, ["mean", "index"], sortOrder);
         }
         return ims;
     });
 
-    function generateStats(){
+    function generateStats() {
 
         let labels = [];
         let datasets = []
 
         // Sorted labels
-        indexMean.map(im =>{
-           labels.push(fieldConfig.sublabels[im.index]);
+        indexMean.map(im => {
+            labels.push(fieldConfig.sublabels[im.index]);
         });
 
         // Sorted data
-        fieldConfig.options.map((value, optionIndex) =>{
+        fieldConfig.options.map((value, optionIndex) => {
             const values: number[] = [];
-            for(let i = 0; i < indexMean.length; i++){
+            for (let i = 0; i < indexMean.length; i++) {
                 const im = indexMean[i];
                 values.push(fieldStats.histograms[im.index][optionIndex].count);
             }
@@ -66,9 +87,9 @@
         return {labels, datasets};
     }
 
-    $effect(()=>{
+    $effect(() => {
         let {labels, datasets} = generateStats();
-        if(chart){
+        if (chart) {
             chart.data.labels = labels;
             chart.data.datasets = datasets;
             chart.update();
@@ -88,15 +109,15 @@
             options: {
                 scales: {
                     x: {
-                      position: "top"
+                        position: "top"
                     },
                     y: {
                         beginAtZero: true,
                         ticks: {
-                            callback: (value) =>{
+                            callback: (value) => {
                                 const maxCutoff = 80;
                                 const labelValue: string = fieldConfig.sublabels[indexMean[value].index];
-                                if(labelValue.length > maxCutoff)
+                                if (labelValue.length > maxCutoff)
                                     return labelValue.substring(0, maxCutoff) + "...";
                                 else
                                     return labelValue;
@@ -131,7 +152,7 @@
               "btn-outline-primary": !(sortByMean && sortAscending)}}
             onclick={()=>{sortByMean = true; sortAscending=true;}}
     >
-        <i class='bx bx-sort-up' ></i>Sort by lowest mean score
+        <i class='bx bx-sort-up'></i>Sort by lowest mean score
     </button>
     <button
             class={{
@@ -141,7 +162,7 @@
               "btn-outline-primary": !(sortByMean && !sortAscending)}}
             onclick={()=>{sortByMean = true; sortAscending=false;}}
     >
-        <i class='bx bx-sort-down' ></i>Sort by highest mean score
+        <i class='bx bx-sort-down'></i>Sort by highest mean score
     </button>
 
 </div>

--- a/ui_components/src/lib/components/graph/OptionsHistogram.svelte
+++ b/ui_components/src/lib/components/graph/OptionsHistogram.svelte
@@ -1,6 +1,22 @@
 <script lang="ts">
     import {onMount} from "svelte";
-    import Chart from "chart.js/auto"
+    import {
+        Chart,
+        Colors,
+        PieController,
+        Legend,
+        PointElement,
+        ArcElement
+    } from 'chart.js'
+
+    Chart.register(
+        Colors,
+        PieController,
+        Legend,
+        PointElement,
+        ArcElement
+    );
+
     import type {FieldConfig, FieldStats} from "../../interfaces.ts";
 
 
@@ -11,9 +27,9 @@
 
     let {fieldConfig, fieldStats}: Props = $props();
     let chartContainer: HTMLCanvasElement = $state()
-    let chart: Chart|null = $state(null);
+    let chart: Chart | null = $state(null);
 
-    function generateStats(){
+    function generateStats() {
         let labels = [];
         let data = [];
         fieldStats.histogram.map(value => {
@@ -28,9 +44,9 @@
         return {labels, datasets};
     }
 
-    $effect(()=>{
+    $effect(() => {
         let {labels, datasets} = generateStats();
-        if(chart){
+        if (chart) {
             chart.data.labels = labels;
             chart.data.datasets = datasets;
             chart.update();
@@ -53,7 +69,7 @@
 
     })
 </script>
-<div >
-    <canvas bind:this={chartContainer} ></canvas>
+<div>
+    <canvas bind:this={chartContainer}></canvas>
 </div>
 

--- a/ui_components/src/lib/components/graph/ScalarHistogram.svelte
+++ b/ui_components/src/lib/components/graph/ScalarHistogram.svelte
@@ -1,7 +1,24 @@
 <script lang="ts">
-    import * as _ from "lodash"
+    import * as _ from "lodash-es"
     import {onMount} from "svelte";
-    import Chart from "chart.js/auto"
+    import {
+        Chart,
+        Colors,
+        LineController,
+        LinearScale,
+        LineElement,
+        Legend,
+        PointElement
+    } from 'chart.js'
+
+    Chart.register(
+        Colors,
+        LineController,
+        LineElement,
+        LinearScale,
+        Legend,
+        PointElement
+    );
     import type {FieldConfig, FieldStats} from "../../interfaces.ts";
 
 

--- a/ui_components/src/lib/components/input/SectionComponent.svelte
+++ b/ui_components/src/lib/components/input/SectionComponent.svelte
@@ -17,7 +17,7 @@
     ]
 </script>
 <script lang="ts">
-    import * as _ from "lodash"
+    import * as _ from "lodash-es"
     import InputComponent, {getDefaultFieldConfig} from "./InputComponent.svelte";
     import EditableText from "./EditableText.svelte";
     import EditableTextArea from "./EditableTextArea.svelte";

--- a/ui_components/src/lib/components/input/Text.svelte
+++ b/ui_components/src/lib/components/input/Text.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import {getUniqueID} from "../../misc.svelte.js";
   import {TextType} from "../../interfaces.ts";
-  import {toNumber} from "lodash";
 
   let {config, value = $bindable(), viewerMode = false} = $props();
 

--- a/ui_components/src/lib/misc.svelte.ts
+++ b/ui_components/src/lib/misc.svelte.ts
@@ -1,4 +1,4 @@
-import * as _ from 'lodash';
+import * as _ from "lodash-es";
 import {
     type FieldConfig,
     type FieldStats,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
     }
   },
   build: {
-    manifest: true,
+    manifest: "manifest.json",
 
     rollupOptions: {
       input: {


### PR DESCRIPTION
Resolve #212 

- Change manifest path to `ui-components/manifest.json` as collectstatic does not copy folder with `.` prefix.
- Manifest now loaded to a global variable `VITE_MANIFEST` in the `vite_integration.py` templatetag
- Start loading generated css assets from manifest
- Use `lodash-es` instead of `lodash` to allow tree shaking
- Importing only specific chartjs modules