### PR TITLE
Send invite email to multiple recipients

### DIFF
--- a/SORT/settings.py
+++ b/SORT/settings.py
@@ -65,6 +65,8 @@ INSTALLED_APPS = [
     "django_extensions",
     "debug_toolbar",
     "qr_code",
+    "crispy_forms",
+    "crispy_bootstrap5",
     # apps created by FA:
     "home",
     "survey",
@@ -240,3 +242,8 @@ SURVEY_TEMPLATES = {
     "Midwives": "sort_only_config_midwives.json",
     "NMAHPs": "sort_only_config_nmahps.json",
 }
+
+# Crispy enables Bootstrap styling on Django forms
+# https://django-crispy-forms.readthedocs.io/en/latest/install.html
+CRISPY_ALLOWED_TEMPLATE_PACKS = "bootstrap5"
+CRISPY_TEMPLATE_PACK = "bootstrap5"

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,5 @@ pytest==8.3.4
 pytest-django==4.9.0
 django-qr-code==4.1.0
 factory-boy==3.3.3
+django-crispy-forms==2.4
+crispy-bootstrap5==2025.4

--- a/survey/forms.py
+++ b/survey/forms.py
@@ -12,7 +12,13 @@ class InvitationForm(forms.Form):
         help_text="Please enter a list of email addresses",
         required=True,
         validators=[EmailListValidator()],
-        widget=forms.Textarea,
+        widget=forms.Textarea(attrs=dict(rows=6)),
+    )
+    message = forms.CharField(
+        label="Message",
+        help_text="(Optional) Additional message for the participants",
+        required=False,
+        widget=forms.Textarea(attrs=dict(rows=3)),
     )
 
 

--- a/survey/forms.py
+++ b/survey/forms.py
@@ -3,13 +3,16 @@ from django.core.validators import EmailValidator
 from django.forms import BaseFormSet, formset_factory
 from strenum import StrEnum
 
+from .validators.email_list_validator import EmailListValidator
+
 
 class InvitationForm(forms.Form):
-    email = forms.EmailField(
-        label="Participant Email",
-        max_length=100,
+    email = forms.CharField(
+        label="Participant Emails",
+        help_text="Please enter a list of email addresses",
         required=True,
-        validators=[EmailValidator()],
+        validators=[EmailListValidator()],
+        widget=forms.Textarea,
     )
 
 

--- a/survey/templates/invitations/send_invitation.html
+++ b/survey/templates/invitations/send_invitation.html
@@ -15,10 +15,10 @@
                     {% csrf_token %}
 
                     <div class="mb-3">
-                        <label for="id_email" class="form-label">Email Address</label>
-                        <input type="email" name="email" id="id_email" class="form-control"
-                               placeholder="Enter email address" required>
-                        <small class="form-text text-muted">Enter the participant's email address.</small>
+                        <label for="id_email" class="form-label">Email Addresses</label>
+                        <textarea type="email" name="email" id="id_email" class="form-control"
+                                  placeholder="Enter email addresses..." rows="5" required></textarea>
+                        <small class="form-text text-muted">Enter the participants email addresses.</small>
                     </div>
 
                     <div class="mb-3">

--- a/survey/templates/invitations/send_invitation.html
+++ b/survey/templates/invitations/send_invitation.html
@@ -1,38 +1,17 @@
 {% extends 'base_manager.html' %}
-
+{% load crispy_forms_tags %}
 {% block content %}
     <div class="container mx-auto px-4 py-8 mt-4">
         <div>
             <h1>Invitations</h1>
             <p class="subtitle">Use the form below to send out invitations to your survey participants.</p>
         </div>
-
-
         <div class="card custom-card shadow-sm my-4">
             <div class="card-body">
-
                 <form method="post">
                     {% csrf_token %}
-
-                    <div class="mb-3">
-                        <label for="id_email" class="form-label">Email Addresses</label>
-                        <textarea type="email" name="email" id="id_email" class="form-control"
-                                  placeholder="Enter email addresses..." rows="5" required></textarea>
-                        <small class="form-text text-muted">Enter the participants email addresses.</small>
-                    </div>
-
-                    <div class="mb-3">
-                        <label for="id_message" class="form-label">Message (Optional)</label>
-                        <textarea name="message" id="id_message" class="form-control" rows="3"
-                                  placeholder="Write your message here..."></textarea>
-                        <small class="form-text text-muted">Add any additional messages.</small>
-                    </div>
-
-                    <div class="text-center">
-                        <button type="submit" class="btn btn-primary" style="background-color: #6933AD; border: none;">
-                            Send
-                        </button>
-                    </div>
+                    {{ form | crispy }}
+                    <button type="submit" class="btn btn-primary">Send</button>
                 </form>
             </div>
 

--- a/survey/urls.py
+++ b/survey/urls.py
@@ -98,6 +98,5 @@ urlpatterns = [
         views.SurveyLinkInvalidView.as_view(),
         name="survey_link_invalid",
     ),
-    path("invite/<int:pk>", views.InvitationView.as_view(), name="invite"),
-
+    path("survey/<int:pk>/invite", views.InvitationView.as_view(), name="invite"),
 ]

--- a/survey/validators/email_list_validator.py
+++ b/survey/validators/email_list_validator.py
@@ -1,0 +1,19 @@
+from django.core.validators import EmailValidator
+
+
+class EmailListValidator(EmailValidator):
+    """
+    Validate a sequence of email addresses.
+    """
+
+    @classmethod
+    def clean(cls, value):
+        """
+        Separate strings by commas or whitespace.
+        """
+        # Replace commas with whitespace
+        return [email.strip() for email in value.replace(",", " ").lower().split()]
+
+    def __call__(self, value):
+        for email in self.clean(value):
+            super().__call__(email)

--- a/survey/validators/email_list_validator.py
+++ b/survey/validators/email_list_validator.py
@@ -5,6 +5,7 @@ class EmailListValidator(EmailValidator):
     """
     Validate a sequence of email addresses.
     """
+    message = "Enter valid email addresses."
 
     @classmethod
     def clean(cls, value):

--- a/survey/views.py
+++ b/survey/views.py
@@ -456,7 +456,7 @@ class InvitationView(FormView):
     form_class = InvitationForm
 
     def form_valid(self, form):
-        email = form.cleaned_data["email"]
+        recipient_list = tuple(form.cleaned_data["email"].split())
         message = form.data["message"]
         survey = Survey.objects.get(pk=self.kwargs["pk"])
         # Generate the survey link with the token
@@ -468,12 +468,12 @@ class InvitationView(FormView):
             subject="Your SORT Survey Invitation",
             message=f"Click here to start the SORT survey:\n{survey_link}\n\n{message}",
             from_email=settings.DEFAULT_FROM_EMAIL,
-            recipient_list=[email],
+            recipient_list=recipient_list,
             fail_silently=False,
         )
 
         # Show success message
-        messages.success(self.request, f"Invitation sent to {email}.")
+        messages.success(self.request, f"Invitation sent to {recipient_list}.")
         return super().form_valid(form)
 
     def get_success_url(self):

--- a/survey/views.py
+++ b/survey/views.py
@@ -456,7 +456,7 @@ class InvitationView(FormView):
     form_class = InvitationForm
 
     def form_valid(self, form):
-        recipient_list = tuple(form.cleaned_data["email"].split())
+        recipient_list = tuple(form.cleaned_data["email"].replace(",", " ").split())
         message = form.data["message"]
         survey = Survey.objects.get(pk=self.kwargs["pk"])
         # Generate the survey link with the token
@@ -473,7 +473,7 @@ class InvitationView(FormView):
         )
 
         # Show success message
-        messages.success(self.request, f"Invitation sent to {recipient_list}.")
+        messages.success(self.request, f"Invitation sent to {len(recipient_list)} recipients.")
         return super().form_valid(form)
 
     def get_success_url(self):


### PR DESCRIPTION
Issue #243 

Changes:
- On the survey invite "send email" page, the email address input is now a `textarea` field that accepts multiple email addresses (either space or comma delimited - so they can copy-paste from Excel)
- Added `EmailListValidator` to verify the form entry
- I had to add the [Crispy forms](https://django-crispy-forms.readthedocs.io/en/latest/) plugin to make the form render properly using Bootstrap styles.

![image](https://github.com/user-attachments/assets/6d14cb24-6d52-44f1-81b8-43c7752dc640)

![image](https://github.com/user-attachments/assets/bc1540f6-798e-4ad4-ba7d-19113fbe0973)

