### PR TITLE
Add link in navigation bar for reporting issues

### DIFF
--- a/static/templates/base_manager.html
+++ b/static/templates/base_manager.html
@@ -35,6 +35,9 @@
                                 {% if '/invite' in request.path %}active{% endif %}"
                                 href="{% url 'myorganisation' %}"><i class="bx bxs-buildings"></i> My Organisation</a>
                         </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="https://docs.google.com/forms/d/e/1FAIpQLSfy6nXvjBiKroZnF92lJjYjMDsldxMnamlObfKDxNDZkIWzvw/viewform?usp=dialog" target="_blank"><i class='bx bxs-bug' ></i> Report issues <i class='bx bx-link-external' ></i></a>
+                        </li>
                     </ul>
                     <ul class="navbar-nav">
                         {% if user.is_authenticated %}


### PR DESCRIPTION
Resolves #222 

![image](https://github.com/user-attachments/assets/d001b7fd-a70f-4462-9700-495f53d962d7)


Google form and results spreadsheet are in the [bug_report](https://drive.google.com/drive/u/0/folders/1hzgnQq60NsVurGe9OmCUnPeTU3zAulno) folder.