### PR TITLE
Move summary matrix to top, add maturity text label

### DIFF
--- a/ui_components/src/lib/components/SortLikertStats.svelte
+++ b/ui_components/src/lib/components/SortLikertStats.svelte
@@ -5,7 +5,7 @@
     import {
         formatNumber,
         getHighestHistogramValue,
-        getHistogramMean,
+        getHistogramMean, getSortMaturityLabel,
     } from "../misc.svelte.ts";
     type QM = {
         index: number;
@@ -53,7 +53,8 @@
 <p>
     Section {sectionConfig.title} demonstrates an overall score <strong>
     of {formatNumber(surveyStats.sections[sectionIndex].fields[fieldIndex].mean)} out of
-    {getHighestHistogramValue(surveyStats.sections[sectionIndex].fields[fieldIndex].histograms[0])}</strong>.
+    {getHighestHistogramValue(surveyStats.sections[sectionIndex].fields[fieldIndex].histograms[0])}</strong> indicating maturity
+    ranking of <strong>{getSortMaturityLabel(surveyStats.sections[sectionIndex].fields[fieldIndex].mean)}</strong>.
     Areas of strength are demonstrated in questions <strong>{strongestAreas}</strong>.
     Areas of improvements are identified in questions <strong>{weakestAreas}</strong>.
 </p>

--- a/ui_components/src/lib/components/SortSummaryMatrix.svelte
+++ b/ui_components/src/lib/components/SortSummaryMatrix.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
     import type {SurveyConfig, SurveyStats} from "../interfaces.ts";
-    import {formatNumber, getColourForMeanValue, getTextColourForMeanValue} from "../misc.svelte.ts";
+    import {
+        formatNumber,
+        getColourForMeanValue,
+        getSortMaturityLabel,
+        getTextColourForMeanValue
+    } from "../misc.svelte.ts";
     interface Props {
         config: SurveyConfig;
         surveyStats: SurveyStats | null;
@@ -32,7 +37,7 @@
     <tr>
         {#each sectionMean as mean}
             <td style="text-align: center; background: {getColourForMeanValue(mean)};">
-                <strong style="color: {getTextColourForMeanValue(mean)}">{formatNumber(mean)}</strong>
+                <strong style="color: {getTextColourForMeanValue(mean)}">{getSortMaturityLabel(mean)} ({formatNumber(mean)})</strong>
             </td>
         {/each}
     </tr>

--- a/ui_components/src/lib/components/SurveyDataView.svelte
+++ b/ui_components/src/lib/components/SurveyDataView.svelte
@@ -53,6 +53,13 @@
     {/if}
     {#if config && surveyStats}
 
+        <div class="card mb-3">
+            <div class="card-header"><h3>Summary Ranking Matrix</h3></div>
+            <div class="card-body">
+                <p>Summary of survey participant's overall average perception for each section.</p>
+                <SortSummaryMatrix config={config} surveyStats={surveyStats}></SortSummaryMatrix>
+            </div>
+        </div>
 
         {#each config.sections as sectionConfig, si (si)}
             {#if sectionConfig.type !== "consent"}
@@ -71,13 +78,7 @@
             {/if}
         {/each}
 
-        <div class="card mb-3">
-            <div class="card-header"><h3>Summary Ranking Matrix</h3></div>
-            <div class="card-body">
-                <p>Summary of survey participant's overall average perception for each section.</p>
-                <SortSummaryMatrix config={config} surveyStats={surveyStats}></SortSummaryMatrix>
-            </div>
-        </div>
+
     {:else}
         <p>No statistics available.</p>
     {/if}

--- a/ui_components/src/lib/misc.svelte.ts
+++ b/ui_components/src/lib/misc.svelte.ts
@@ -332,3 +332,17 @@ export function getTextColourForMeanValue(mean: number): string {
     }
     return colourRange[0].textColour;
 }
+
+export function getSortMaturityLabel(score: number) {
+    if (score < 1.5) {
+        return "Not yet planned";
+    } else if (score >= 1.5 && score < 2.5) {
+        return "Planned";
+    } else if (score >= 2.5 && score < 3.5) {
+        return "Early progress";
+    } else if (score >= 3.5 && score < 4.5) {
+        return "Substantial progress";
+    } else {
+        return "Established"
+    }
+}


### PR DESCRIPTION
Resolves #249 

- Move summary matrix to top
- Add maturity text label, categories changes at .5 instead of on the whole number i.e. anything less than 1.5 is Not yet planned, 1.5 to < 2.5 is Planned and so on.
- Add maturity text label to the summary matrix and the likert chart summary at the top of each section.

![image](https://github.com/user-attachments/assets/df53dede-7465-4d61-8559-1d907aa854dd)
