### PR TITLE
Make demographics fields read-only

### DIFF
--- a/data/survey_config/demography_only_config.json
+++ b/data/survey_config/demography_only_config.json
@@ -15,7 +15,8 @@
           "maxNumChar": 500,
           "minNumValue": 0,
           "maxNumValue": 100,
-          "textType": "INTEGER_TEXT"
+          "textType": "INTEGER_TEXT",
+          "readOnly":  true
         },
         {
           "type": "radio",
@@ -23,7 +24,8 @@
           "description": "",
           "required": true,
           "sublabels": [],
-          "options": ["Male", "Female", "Non-binary", "Prefer not to say"]
+          "options": ["Male", "Female", "Non-binary", "Prefer not to say"],
+          "readOnly":  true
         },
         {
           "type": "text",
@@ -35,21 +37,24 @@
           "maxNumChar": 500,
           "minNumValue": 0,
           "maxNumValue": 100,
-          "textType": "INTEGER_TEXT"
+          "textType": "INTEGER_TEXT",
+          "readOnly":  true
         },
         {
           "type": "radio",
           "label": "What is your current Band/Grade",
           "required": true,
           "sublabels": [],
-          "options": ["Band 5 ", "Band 6", "Band 7", "Band 8", "Band 9"]
+          "options": ["Band 5 ", "Band 6", "Band 7", "Band 8", "Band 9"],
+          "readOnly":  true
         },
         {
           "type": "radio",
           "label": "Please indicate your highest qualification",
           "required": true,
           "sublabels": [],
-          "options": ["Diploma", "Degree", "Masters", "PhD/Doctorate"]
+          "options": ["Diploma", "Degree", "Masters", "PhD/Doctorate"],
+          "readOnly":  true
         },
         {
           "type": "radio",
@@ -73,9 +78,9 @@
             "White - Irish"                  ,
             "White - Romany"                 ,
             "Other"
-          ]
+          ],
+          "readOnly":  true
         }
-
       ]
     }
   ]

--- a/ui_components/src/lib/components/input/InputComponent.svelte
+++ b/ui_components/src/lib/components/input/InputComponent.svelte
@@ -136,7 +136,11 @@
         endEdit();
     }
 
-
+    // Input label
+    let ariaLabel = 'Click to edit field';
+    if (config.readOnly) {
+        ariaLabel = 'This field cannot be edited';
+    }
 </script>
 
 {#snippet enforceMaxChar()}
@@ -293,12 +297,13 @@
 {:else if editable && !inEditMode}
     <a href="/assets/ui_components/public"
        class="card mb-3 sort-form-component"
-       aria-label="Click to edit field"
+       title={ariaLabel}
+       aria-label={ariaLabel}
        draggable="true"
        ondragstart={onDragStartHandler}
        ondrop={onDropHandler}
        ondragover={onDragOverHandler}
-       onclick={(event)=>{event.preventDefault(); beginEdit()}}
+       onclick={(event)=>{event.preventDefault(); if (!config.readOnly) {beginEdit()}}}
     >
         <div class="card-body">
             <RenderedComponentType config={config}></RenderedComponentType>


### PR DESCRIPTION
re:
- #135 

While in survey configurator GUI mode, any field with `readOnly = true` will not be allowed to go into the editable state, as this Boolean value is evaluated on the `onclick` action.

Any field without a `readOnly` property will default to readOnly = false i.e. editable. This should retain the normal behaviour for all the other fields in the system.

Problems:
- Any existing surveys will need to be changed so that `readOnly` is false for all existing demographics fields.
- This doesn't block changes at the database or backend (Python Django) level, only in the GUI.