### PR TITLE
Add a disable option to each field

### DIFF
--- a/data/survey_config/demography_only_config.json
+++ b/data/survey_config/demography_only_config.json
@@ -15,7 +15,8 @@
           "maxNumChar": 500,
           "minNumValue": 0,
           "maxNumValue": 100,
-          "textType": "INTEGER_TEXT"
+          "textType": "INTEGER_TEXT",
+          "disabled": false
         },
         {
           "type": "radio",
@@ -23,7 +24,8 @@
           "description": "",
           "required": true,
           "sublabels": [],
-          "options": ["Male", "Female", "Non-binary", "Prefer not to say"]
+          "options": ["Male", "Female", "Non-binary", "Prefer not to say"],
+          "disabled": false
         },
         {
           "type": "text",
@@ -35,21 +37,24 @@
           "maxNumChar": 500,
           "minNumValue": 0,
           "maxNumValue": 100,
-          "textType": "INTEGER_TEXT"
+          "textType": "INTEGER_TEXT",
+          "disabled": false
         },
         {
           "type": "radio",
           "label": "What is your current Band/Grade",
           "required": true,
           "sublabels": [],
-          "options": ["Band 5 ", "Band 6", "Band 7", "Band 8", "Band 9"]
+          "options": ["Band 5 ", "Band 6", "Band 7", "Band 8", "Band 9"],
+          "disabled": false
         },
         {
           "type": "radio",
           "label": "Please indicate your highest qualification",
           "required": true,
           "sublabels": [],
-          "options": ["Diploma", "Degree", "Masters", "PhD/Doctorate"]
+          "options": ["Diploma", "Degree", "Masters", "PhD/Doctorate"],
+          "disabled": false
         },
         {
           "type": "radio",
@@ -73,7 +78,8 @@
             "White - Irish"                  ,
             "White - Romany"                 ,
             "Other"
-          ]
+          ],
+          "disabled": false
         }
 
       ]

--- a/ui_components/src/lib/components/input/InputComponent.svelte
+++ b/ui_components/src/lib/components/input/InputComponent.svelte
@@ -276,10 +276,19 @@
                 </div>
             {/if}
 
+            <!-- Required switch -->
             <div class="form-check form-switch mb-3">
                 <label class="form-label">
                     Required
                     <input type="checkbox" class="form-check-input" role="switch" bind:checked={config.required}/>
+                </label>
+            </div>
+
+            <!-- Disabled switch -->
+            <div class="form-check form-switch mb-3">
+                <label class="form-label">
+                    Disabled
+                    <input type="checkbox" class="form-check-input" role="switch" bind:checked={config.disabled}/>
                 </label>
             </div>
 
@@ -304,6 +313,8 @@
             <RenderedComponentType config={config}></RenderedComponentType>
         </div>
     </a>
+{:else if config.disabled}
+    <!-- This field is disabled -->
 {:else}
     <RenderedComponentType config={config} bind:value={value} bind:this={renderedComponent} viewerMode={viewerMode}></RenderedComponentType>
 {/if}

--- a/ui_components/src/lib/components/input/InputComponent.svelte
+++ b/ui_components/src/lib/components/input/InputComponent.svelte
@@ -64,7 +64,8 @@
         onDeleteRequest = () => {
         },
         onMoveRequest = (srcSectionIndex, srcFieldIndex, destSectionIndex, destFieldIndex) => {
-        }
+        },
+        canDisableFields = false,
     } = $props();
 
 
@@ -284,6 +285,7 @@
                 </label>
             </div>
 
+            {#if canDisableFields }
             <!-- Disabled switch -->
             <div class="form-check form-switch mb-3">
                 <label class="form-label">
@@ -291,6 +293,7 @@
                     <input type="checkbox" class="form-check-input" role="switch" bind:checked={config.disabled}/>
                 </label>
             </div>
+            {/if}
 
             <div>
                 <button class="btn btn-primary" onclick={() => {onDuplicateRequest()}}><i class="bx bx-duplicate"></i> Duplicate</button>

--- a/ui_components/src/lib/components/input/SectionComponent.svelte
+++ b/ui_components/src/lib/components/input/SectionComponent.svelte
@@ -97,6 +97,8 @@
         }
     }
 
+    // Only allow fields to be deactivated in the demography section
+    let canDisableFields = config.type == "demographic";
 
 </script>
 
@@ -167,6 +169,7 @@
                         sectionIndex={sectionIndex}
                         fieldIndex={index}
                         onMoveRequest={handleMoveRequest}
+                        canDisableFields={canDisableFields}
                 />
             </div>
         {/each}


### PR DESCRIPTION
re:
- #135 
- https://github.com/RSE-Sheffield/SORT/pull/281

For each field, if `disabled = true` then that item isn't rendered.

This toggle switch is only available in the demographics section of the survey configuration GUI.

**Screenshots:**
![image](https://github.com/user-attachments/assets/d9dde264-467b-4be8-bc32-4ca6f78fcef7)
![image](https://github.com/user-attachments/assets/533c02f9-14b6-4f81-83b0-3a1406d54f68)
