### PR TITLE
Add object IDs everywhere

### DIFF
--- a/home/admin.py
+++ b/home/admin.py
@@ -3,7 +3,7 @@ from django.contrib import admin
 from .models import Organisation, OrganisationMembership, Project, User
 
 
-# Register your models here.
+@admin.register(User)
 class UserAdmin(admin.ModelAdmin):
     list_display = ("email", "first_name", "last_name", "is_staff", "date_joined")
     search_fields = ("email", "first_name", "last_name")
@@ -11,25 +11,22 @@ class UserAdmin(admin.ModelAdmin):
     ordering = ("-date_joined",)
 
 
+@admin.register(Organisation)
 class OrganisationAdmin(admin.ModelAdmin):
-    list_display = ("name", "created_at")
-    search_fields = ("name",)
+    list_display = ("pk", "name", "created_at")
+    search_fields = ("name", "description",)
     ordering = ("name",)
 
 
+@admin.register(OrganisationMembership)
 class OrganisationMembershipAdmin(admin.ModelAdmin):
     list_display = ("user", "organisation", "role", "joined_at")
     list_filter = ("role",)
     search_fields = ("user__email", "organisation__name")
 
 
+@admin.register(Project)
 class ProjectAdmin(admin.ModelAdmin):
-    list_display = ("name", "created_by", "created_at")
-    search_fields = ("name",)
-    list_filter = ("created_at",)
-
-
-admin.site.register(User, UserAdmin)
-admin.site.register(Organisation, OrganisationAdmin)
-admin.site.register(Project, ProjectAdmin)
-admin.site.register(OrganisationMembership, OrganisationMembershipAdmin)
+    list_display = ("pk", "name", "created_by", "created_at", "organisation")
+    search_fields = ("name", "description",)
+    list_filter = ("organisation",)

--- a/home/templates/organisation/organisation.html
+++ b/home/templates/organisation/organisation.html
@@ -46,7 +46,7 @@
             {% for project in projects %}
                 <div class="card w-100">
                     <div class="card-body">
-                        <p class="h5 card-title">{{ project.name }}</p>
+                        <p class="h5 card-title" title="Project identifier {{ project.pk }}">{{ project.name }}</p>
                         <p class="h6 card-subtitle text-muted mb-2">{{ project.description|default_if_none:"No description provided." }}</p>
                         <p class="h7 card-text">Surveys: {{ project.survey_count }}</p>
 

--- a/home/templates/projects/list.html
+++ b/home/templates/projects/list.html
@@ -14,7 +14,7 @@
       {% for project in projects %}
         <div class="card w-100">
           <div class="card-body">
-            <h2 class="card-title">{{ project.name }}</h2>
+            <h2 class="card-title" title="Project identifier {{ project.pk }}">{{ project.name }}</h2>
             <div class="card-text">
               <div class="flex flex-wrap gap-2 mb-3">
                 {% for org in project_orgs|get_item:project.id %}<span class="badge text-bg-primary">{{ org.name }}</span>{% endfor %}

--- a/home/templates/projects/project.html
+++ b/home/templates/projects/project.html
@@ -53,7 +53,7 @@
         {% for survey in surveys %}
             <div class="card w-100">
                 <div class="card-body">
-                    <h3 class="card-title">{{ survey.name }}</h3>
+                    <h3 class="card-title" title="Survey identifier {{ survey.pk }}">{{ survey.name }}</h3>
                     <div class="card-text">
                         <span>Responses: {{ survey.survey_response.count | default:0 }}</span>
                     </div>

--- a/survey/admin.py
+++ b/survey/admin.py
@@ -10,15 +10,29 @@ from .models import (
 )
 
 
+@admin.register(Invitation)
 class InvitationAdmin(admin.ModelAdmin):
     list_display = ("survey", "token", "created_at", "used")
     search_fields = ("token",)
     ordering = ("created_at",)
 
 
-admin.site.register(Survey)
-admin.site.register(SurveyResponse)
+@admin.register(Survey)
+class SurveyAdmin(admin.ModelAdmin):
+    list_display = ("pk", "name", "created_at", "project", "project__organisation")
+    search_fields = ("name", "description",)
+    ordering = ("created_at",)
+    list_filter = ("project", "project__organisation",)
+
+
+@admin.register(SurveyResponse)
+class SurveyResponseAdmin(admin.ModelAdmin):
+    list_display = ("pk", "survey", "created_at", "survey__project", "survey__project__organisation",)
+    ordering = ("created_at",)
+    date_hierarchy = "created_at"
+    list_filter = ("survey__project", "survey__project__organisation", "created_at")
+
+
 admin.site.register(SurveyEvidenceSection)
 admin.site.register(SurveyFile)
 admin.site.register(SurveyEvidenceFile)
-admin.site.register(Invitation, InvitationAdmin)

--- a/survey/models.py
+++ b/survey/models.py
@@ -44,6 +44,13 @@ class Survey(models.Model):
 
         return None
 
+    @property
+    def reference_number(self) -> str:
+        """
+        Unique identifier e.g. "SURVEY-000001"
+        """
+        return f"{self.__class__.__name__.upper()}-{str(self.pk).zfill(6)}"
+
 
 class SurveyEvidenceSection(models.Model):
     """

--- a/survey/models.py
+++ b/survey/models.py
@@ -125,6 +125,9 @@ class SurveyResponse(models.Model):
     answers = models.JSONField()
     created_at = models.DateTimeField(auto_now_add=True)
 
+    def __str__(self):
+        return f"Survey {self.survey.pk} response {self.pk}"
+
     def get_absolute_url(self, token):
         return reverse("survey", kwargs={"pk": self.survey.pk})
 

--- a/survey/templates/survey/survey.html
+++ b/survey/templates/survey/survey.html
@@ -1,6 +1,17 @@
 {% extends 'base_manager.html' %}
 {% load qr_code %}
 {% block content %}
+    <script lang="js">
+    const copyToClipboard = async (selectors = ".user-select-all") => {
+      try {
+        const element = document.querySelector(selectors);
+        await navigator.clipboard.writeText(element.textContent);
+      } catch (error) {
+        console.error("Failed to copy to clipboard:", error);
+        throw error;
+      }
+    };
+    </script>
     {% load project_filters %}
     <div class="container mx-auto px-4 py-8 mt-4">
         <nav aria-label="breadcrumb">
@@ -21,12 +32,19 @@
     <div class="container mx-auto px-4 py-8">
         <div class="card mb-3">
             <div class="card-header">
-                <h1>{{ survey.name }}</h1>
+                <h1 title="Reference number {{ survey.reference_number }}">{{ survey.name }}</h1>
             </div>
             <div class="card-body">
                 <p><strong>Survey description:</strong></p>
                 <p>{{ survey.description }}</p>
                 <p><strong>Created on:</strong> {{ survey.created_at }}</p>
+                <p>
+                    <strong>Unique identifier:</strong>
+                    <span id="reference-number" class="user-select-all">{{ survey.reference_number }}</span>
+                    <button class="btn btn-secondary p-1" onclick="copyToClipboard()" title="Copy to clipboard">
+                        <i class="bx bx-copy"></i>
+                    </button>
+                </p>
                 <div class="d-flex justify-content-between mt-3">
                     <div></div>
                     <div></div>
@@ -35,7 +53,6 @@
                     <div>
                         <a href="{% url 'survey_duplicate_config' survey.pk %}" class="btn btn-primary"><i class='bx bxs-copy' ></i> Create a new survey using current configurations.</a>
                     </div>
-
                 </div>
             </div>
         </div>

--- a/survey/templates/survey/survey.html
+++ b/survey/templates/survey/survey.html
@@ -39,7 +39,7 @@
                 <p>{{ survey.description }}</p>
                 <p><strong>Created on:</strong> {{ survey.created_at }}</p>
                 <p>
-                    <strong>Unique identifier:</strong>
+                    <strong>Reference number:</strong>
                     <span id="reference-number" class="user-select-all">{{ survey.reference_number }}</span>
                     <button class="btn btn-secondary p-1" onclick="copyToClipboard()" title="Copy to clipboard">
                         <i class="bx bx-copy"></i>

--- a/survey/templates/survey/survey_response.html
+++ b/survey/templates/survey/survey_response.html
@@ -2,7 +2,6 @@
 {% load static %}
 {% load vite_integration %}
 {% block content %}
-
 <div class="container mx-auto px-4 py-8 m-3">
     <div class="sort-survey-response" data-json-config-id="configData"></div>
 </div>
@@ -11,4 +10,10 @@
 {{ survey.survey_config | json_script:"configData" }}
 {% vite_client %}
 {% vite_asset 'src/main.ts' %}
+<div class="container">
+    <p class="text-secondary text-sm-center">
+        <strong>Survey reference number:</strong>
+        <span class="user-select-all">{{ survey.reference_number }}</span>
+    </p>
+</div>
 {% endblock %}


### PR DESCRIPTION
**Resolves:**
- https://github.com/RSE-Sheffield/SORT/issues/296

**Changes:**
- Customised [Django admin site](https://docs.djangoproject.com/en/5.2/ref/contrib/admin/) to show object IDs, etc.
- Added a unique reference number for each survey that the user can copy (it's shown on the survey management page and the survey response view.)
- Added tooltips to headers that show the PK to the user

**Screenshots**
![image](https://github.com/user-attachments/assets/e37a9702-698f-4f56-b53f-5cbedea7d959)
![image](https://github.com/user-attachments/assets/63c6586a-135c-44e4-ab4e-f44ec9e778bf)
![image](https://github.com/user-attachments/assets/b301176e-ea5a-4984-81f5-6e6cee13862c)
