### PR TITLE
Add bar charts

### DIFF
--- a/survey/templates/survey/evidence_gathering.html
+++ b/survey/templates/survey/evidence_gathering.html
@@ -48,13 +48,12 @@
                 <h3>{{ section_config.title }}</h3>
             </div>
             <div>
-                <h5>Survey summary</h5>
-
                 <div
                         class="sort-response-section-viewer"
                         data-json-config-id="configData"
                         data-json-responses-id="responsesData"
                         data-section-index="{{ evidence_section.section_id }}"
+                        data-use-bar-chart="true"
                 ></div>
 
 
@@ -83,7 +82,7 @@
                         Published report
                     </li>
                     <li>
-                        Planning document for the initatives
+                        Planning document for the initiatives
                     </li>
                     <li>
                         etc.

--- a/survey/templates/survey/improvement_plan.html
+++ b/survey/templates/survey/improvement_plan.html
@@ -54,6 +54,7 @@
                         data-json-config-id="configData"
                         data-json-responses-id="responsesData"
                         data-section-index="{{ evidence_section.section_id }}"
+                        data-use-bar-chart="true"
                 ></div>
 
                 <h5>Evidence statement</h5>

--- a/survey/templates/survey/report.html
+++ b/survey/templates/survey/report.html
@@ -35,6 +35,7 @@
                                 data-json-responses-id="responsesData"
                                 data-json-readiness-descriptions-id="readinessDescriptions"
                                 data-section-index="{{ forloop.counter0 }}"
+                                data-use-bar-chart="false"
                         ></div>
 
                         {% if section.evidence %}

--- a/ui_components/src/lib/components/SortLikertStats.svelte
+++ b/ui_components/src/lib/components/SortLikertStats.svelte
@@ -19,7 +19,7 @@
         fieldIndex: number,
         readinessDescriptions: string[],
     }
-    let {config, surveyStats, sectionIndex, fieldIndex, readinessDescriptions}: Props = $props();
+    let {config, surveyStats, sectionIndex, fieldIndex, readinessDescriptions = []}: Props = $props();
 
     let sectionConfig = $derived(config.sections[sectionIndex]);
     let fieldConfig = $derived(config.sections[sectionIndex].fields[fieldIndex]);
@@ -60,7 +60,9 @@
     of {sectionMeanReadiness.toFixed(2)} out of
     {getHighestHistogramValue(surveyStats.sections[sectionIndex].fields[fieldIndex].histograms[0])}</strong> indicating maturity
     ranking of <strong>{getSortMaturityLabel(surveyStats.sections[sectionIndex].fields[fieldIndex].mean)}</strong>.
+    {#if readinessDescription}
     The responses suggest that {readinessDescription}
+    {/if}
 </p>
 <div class="progress">
   <div class="progress-bar bg-secondary" role="progressbar" style="width: {0.2*sectionMeanReadiness*100}%" aria-valuenow="{sectionMeanReadiness}" aria-valuemin="0" aria-valuemax="4">

--- a/ui_components/src/lib/components/SortLikertStats.svelte
+++ b/ui_components/src/lib/components/SortLikertStats.svelte
@@ -2,11 +2,13 @@
     import * as _ from "lodash-es"
     import type {SurveyConfig, SurveyStats} from "../interfaces.ts";
     import LikertHistogram from "./graph/LikertHistogram.svelte";
+    import LikertBarChart from "./graph/LikertBarChart.svelte";
     import {
         formatNumber,
         getHighestHistogramValue,
         getHistogramMean, getSortMaturityLabel,
     } from "../misc.svelte.ts";
+
     type QM = {
         index: number;
         mean: number;
@@ -18,14 +20,23 @@
         sectionIndex: number,
         fieldIndex: number,
         readinessDescriptions: string[],
+        useBarChart: boolean
     }
-    let {config, surveyStats, sectionIndex, fieldIndex, readinessDescriptions = []}: Props = $props();
+
+    let {
+        config,
+        surveyStats,
+        sectionIndex,
+        fieldIndex,
+        readinessDescriptions = [],
+        useBarChart = true
+    }: Props = $props();
 
     let sectionConfig = $derived(config.sections[sectionIndex]);
     let fieldConfig = $derived(config.sections[sectionIndex].fields[fieldIndex]);
-    let questionMeanSorted: QM[] = $derived.by(()=>{
+    let questionMeanSorted: QM[] = $derived.by(() => {
         const qm = [];
-        for(let i =0; i < surveyStats.sections[sectionIndex].fields[fieldIndex].histograms.length; i++){
+        for (let i = 0; i < surveyStats.sections[sectionIndex].fields[fieldIndex].histograms.length; i++) {
             qm.push({
                 index: i,
                 mean: getHistogramMean(surveyStats.sections[sectionIndex].fields[fieldIndex].histograms[i])
@@ -33,7 +44,7 @@
         }
         return _.orderBy(qm, ["mean"], ["asc"]);
     })
-    let strongestAreas: string = $derived.by(()=>{
+    let strongestAreas: string = $derived.by(() => {
         const strongestList = questionMeanSorted.slice(-2);
         const output: string[] = [];
         strongestList.map(qm => {
@@ -41,8 +52,8 @@
         })
         return output;
     })
-    let weakestAreas: string = $derived.by(()=>{
-        const weakestList = questionMeanSorted.slice(0,2);
+    let weakestAreas: string = $derived.by(() => {
+        const weakestList = questionMeanSorted.slice(0, 2);
         const output: string[] = [];
         weakestList.map(qm => {
             output.push(fieldConfig.sublabels[qm.index]);
@@ -51,42 +62,49 @@
     })
     const sectionMeanReadiness: number = surveyStats.sections[sectionIndex].fields[fieldIndex].mean;
     const sectionMeanReadinessInt: bigint = parseInt(sectionMeanReadiness);
-    const readinessDescription: string = readinessDescriptions[sectionMeanReadinessInt-1];
+    const readinessDescription: string = readinessDescriptions[sectionMeanReadinessInt - 1];
 
 </script>
 <h3>Summary <span class="badge badge-secondary bg-secondary">{sectionMeanReadiness.toFixed(0)}</span></h3>
 <p>
     Section {sectionConfig.title} demonstrates an overall score <strong>
     of {sectionMeanReadiness.toFixed(2)} out of
-    {getHighestHistogramValue(surveyStats.sections[sectionIndex].fields[fieldIndex].histograms[0])}</strong> indicating maturity
+    {getHighestHistogramValue(surveyStats.sections[sectionIndex].fields[fieldIndex].histograms[0])}</strong> indicating
+    maturity
     ranking of <strong>{getSortMaturityLabel(surveyStats.sections[sectionIndex].fields[fieldIndex].mean)}</strong>.
     {#if readinessDescription}
-    The responses suggest that {readinessDescription}
+        The responses suggest that {readinessDescription}
     {/if}
 </p>
 <div class="progress">
-  <div class="progress-bar bg-secondary" role="progressbar" style="width: {0.2*sectionMeanReadiness*100}%" aria-valuenow="{sectionMeanReadiness}" aria-valuemin="0" aria-valuemax="4">
-      {sectionMeanReadiness.toFixed(1)} / 5
-  </div>
+    <div class="progress-bar bg-secondary" role="progressbar" style="width: {0.2*sectionMeanReadiness*100}%"
+         aria-valuenow="{sectionMeanReadiness}" aria-valuemin="0" aria-valuemax="4">
+        {sectionMeanReadiness.toFixed(1)} / 5
+    </div>
 </div>
 <h4>Areas of strength</h4>
 <p>Areas of strength are demonstrated in the following questions:</p>
 <ul>
-{#each strongestAreas as strongArea }
-    <li>{strongArea}</li>
-{/each}
+    {#each strongestAreas as strongArea }
+        <li>{strongArea}</li>
+    {/each}
 </ul>
 <h4>Areas for improvement</h4>
 <p>
     Areas of improvements are identified in the following questions:
 </p>
 <ul>
-{#each weakestAreas as weakArea }
-    <li>{weakArea}</li>
-{/each}
+    {#each weakestAreas as weakArea }
+        <li>{weakArea}</li>
+    {/each}
 </ul>
-<LikertHistogram fieldConfig={fieldConfig}
-                                 fieldStats={surveyStats.sections[sectionIndex].fields[fieldIndex]}></LikertHistogram>
+{#if useBarChart}
+    <LikertBarChart fieldConfig={fieldConfig}
+                     fieldStats={surveyStats.sections[sectionIndex].fields[fieldIndex]}></LikertBarChart>
+{:else}
+    <LikertHistogram fieldConfig={fieldConfig}
+                    fieldStats={surveyStats.sections[sectionIndex].fields[fieldIndex]}></LikertHistogram>
+{/if}
 <table class="table table-bordered mt-4">
     <thead>
     <tr>

--- a/ui_components/src/lib/components/SurveySectionDataView.svelte
+++ b/ui_components/src/lib/components/SurveySectionDataView.svelte
@@ -3,6 +3,7 @@
     import type {SurveyConfig, SurveyStats} from "../interfaces.ts";
     import {TextType} from "../interfaces.ts";
     import LikertHistogram from "./graph/LikertHistogram.svelte";
+    import LikertBarChart from "./graph/LikertBarChart.svelte";
     import OptionsHistogram from "./graph/OptionsHistogram.svelte";
     import CollapsibleCard from "./CollapsibleCard.svelte";
     import SortLikertStats from "./SortLikertStats.svelte";
@@ -13,9 +14,10 @@
         surveyStats: SurveyStats | null,
         sectionIndex: number,
         readinessDescriptions: string[],
+        useBarChart: boolean
     }
 
-    let {config, surveyStats, sectionIndex = 0, readinessDescriptions}: Props = $props();
+    let {config, surveyStats, sectionIndex = 0, readinessDescriptions, useBarChart = false}: Props = $props();
     let sectionConfig = $derived(config.sections[sectionIndex]);
 
 </script>
@@ -31,15 +33,20 @@
                             surveyStats={surveyStats}
                             sectionIndex={sectionIndex}
                             fieldIndex={fi}
-                            readinessDescriptions={readinessDescriptions}>
+                            readinessDescriptions={readinessDescriptions}
+                            useBarChart={useBarChart}>
                     </SortLikertStats>
                 </div>
 
             {:else if fieldConfig.type === "likert" }
                 <div class="mb-3 flex-grow-1 flex-fill w-100">
-
+                    {#if useBarChart}
+                    <LikertBarChart fieldConfig={fieldConfig}
+                                     fieldStats={surveyStats.sections[sectionIndex].fields[fi]}></LikertBarChart>
+                    {:else}
                     <LikertHistogram fieldConfig={fieldConfig}
                                      fieldStats={surveyStats.sections[sectionIndex].fields[fi]}></LikertHistogram>
+                    {/if}
                 </div>
             {/if}
             {#if fieldConfig.type === "radio" || fieldConfig.type === "select" || fieldConfig.type === "checkbox"}

--- a/ui_components/src/lib/components/graph/LikertBarChart.svelte
+++ b/ui_components/src/lib/components/graph/LikertBarChart.svelte
@@ -1,0 +1,150 @@
+<script lang="ts">
+    import * as _ from "lodash-es";
+    import {onMount} from "svelte";
+    import {
+        Chart,
+        Colors,
+        BarController,
+        CategoryScale,
+        LinearScale,
+        BarElement,
+        Legend,
+        PointElement,
+        Tooltip,
+
+    } from 'chart.js'
+
+    Chart.register(
+        Colors,
+        BarController,
+        BarElement,
+        CategoryScale,
+        LinearScale,
+        Legend,
+        PointElement,
+        Tooltip,
+    );
+    import type {FieldConfig, FieldStats} from "../../interfaces.ts";
+    import {getColourForMeanValue, getHistogramMean} from "../../misc.svelte.js";
+
+    type IndexMean = {
+        index: number;
+        mean: number;
+    }
+
+    interface LikertHistogramProps {
+        fieldConfig: FieldConfig;
+        fieldStats: FieldStats;
+    }
+
+    let {fieldConfig, fieldStats}: LikertHistogramProps = $props();
+    let barChartContainer: HTMLCanvasElement = $state()
+    let chartHeight = $derived(fieldConfig.sublabels.length * 3); // Reduced height since we're showing less data
+    let chart: Chart | null = $state(null);
+    let sortByMean = $state(false);
+    let sortAscending = $state(true);
+    let indexMean: IndexMean[] = $derived.by(() => {
+        let ims: IndexMean[] = [];
+        fieldStats.histograms.map((value, index) => {
+            ims.push({
+                index: index,
+                mean: getHistogramMean(value)
+            })
+        });
+
+        if (sortByMean) {
+            let sortOrder: (boolean | "asc" | "desc")[] = ["asc", "asc"];
+            if (!sortAscending) sortOrder = ["desc", "desc"];
+            ims = _.orderBy(ims, ["mean", "index"], sortOrder);
+        }
+        return ims;
+    });
+
+    function generateStats() {
+        let labels = [];
+        let meanValues = [];
+        let backgroundColors = [];
+
+        // Generate labels, mean values, and colors
+        indexMean.map(im => {
+            labels.push(fieldConfig.sublabels[im.index]);
+            meanValues.push(im.mean);
+            backgroundColors.push(getColourForMeanValue(im.mean));
+        });
+
+        // Single dataset with mean values
+        const datasets = [{
+            label: 'Mean Score',
+            data: meanValues,
+            backgroundColor: backgroundColors,
+            borderWidth: 1,
+            borderColor: backgroundColors.map(color => color), // Same as background or you could darken them
+        }];
+
+        return {labels, datasets};
+    }
+
+    $effect(() => {
+        let {labels, datasets} = generateStats();
+        if (chart) {
+            chart.data.labels = labels;
+            chart.data.datasets = datasets;
+            chart.update();
+        }
+    })
+
+    onMount(() => {
+        let {labels, datasets} = generateStats();
+
+        chart = new Chart(barChartContainer, {
+            type: 'bar',
+            data: {
+                labels: labels,
+                datasets: datasets,
+            },
+            options: {
+                scales: {
+                    x: {
+                        position: "top",
+                        beginAtZero: true,
+                        max: Math.max(...fieldConfig.options.map(Number)), // Set max to highest possible score
+                        ticks: {
+                            stepSize: 0.5 // Adjust based on your scale
+                        }
+                    },
+                    y: {
+                        ticks: {
+                            callback: (value) => {
+                                const maxCutoff = 80;
+                                const labelValue: string = fieldConfig.sublabels[indexMean[value].index];
+                                if (labelValue.length > maxCutoff)
+                                    return labelValue.substring(0, maxCutoff) + "...";
+                                else
+                                    return labelValue;
+                            }
+                        }
+                    }
+                },
+                indexAxis: 'y',
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: {
+                    legend: {
+                        display: false // Hide legend since we only have one dataset
+                    },
+                    tooltip: {
+                        callbacks: {
+                            label: function(context) {
+                                return `Mean Score: ${context.parsed.x.toFixed(2)}`;
+                            }
+                        }
+                    }
+                }
+            }
+        });
+    })
+</script>
+
+<div style="height: {chartHeight}em;">
+    <canvas bind:this={barChartContainer}></canvas>
+</div>

--- a/ui_components/src/lib/components/graph/LikertBarChart.svelte
+++ b/ui_components/src/lib/components/graph/LikertBarChart.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-    import * as _ from "lodash-es";
     import {onMount} from "svelte";
     import {
         Chart,
@@ -39,10 +38,8 @@
 
     let {fieldConfig, fieldStats}: LikertHistogramProps = $props();
     let barChartContainer: HTMLCanvasElement = $state()
-    let chartHeight = $derived(fieldConfig.sublabels.length * 3); // Reduced height since we're showing less data
+    let chartHeight = $derived(fieldConfig.sublabels.length * 2.5); // Reduced height since we're showing less data
     let chart: Chart | null = $state(null);
-    let sortByMean = $state(false);
-    let sortAscending = $state(true);
     let indexMean: IndexMean[] = $derived.by(() => {
         let ims: IndexMean[] = [];
         fieldStats.histograms.map((value, index) => {
@@ -51,12 +48,6 @@
                 mean: getHistogramMean(value)
             })
         });
-
-        if (sortByMean) {
-            let sortOrder: (boolean | "asc" | "desc")[] = ["asc", "asc"];
-            if (!sortAscending) sortOrder = ["desc", "desc"];
-            ims = _.orderBy(ims, ["mean", "index"], sortOrder);
-        }
         return ims;
     });
 

--- a/ui_components/src/main.ts
+++ b/ui_components/src/main.ts
@@ -1,4 +1,4 @@
-import { mount } from 'svelte'
+import {mount} from 'svelte'
 import {type FileDescriptionType, type SurveyConfig, type SurveyResponseBatch} from "./lib/interfaces.ts"
 import {generateStatsFromSurveyResponses, getDataInElem} from "./lib/misc.svelte.js";
 import SmartTable from "./lib/components/SmartTable.svelte";
@@ -12,16 +12,16 @@ import SortSummaryMatrix from "./lib/components/SortSummaryMatrix.svelte";
 
 const csrf: string = getDataInElem("csrf", []);
 
-function mapMatchedElement(selector: string, handler: (elem: HTMLElement)=> void){
+function mapMatchedElement(selector: string, handler: (elem: HTMLElement) => void) {
     const matchingElements = document.querySelectorAll(selector);
-    for(let i = 0; i < matchingElements.length; i++) {
+    for (let i = 0; i < matchingElements.length; i++) {
         const elem = matchingElements[i] as HTMLElement;
         handler(elem);
     }
 }
 
 
-mapMatchedElement(".sort-consent-demography-config", (elem) =>{
+mapMatchedElement(".sort-consent-demography-config", (elem) => {
     const consentConfigId = elem.dataset.jsonConsentConfigId;
     const demographyConfigId = elem.dataset.jsonDemographyConfigId;
     const surveyBodyPath = elem.dataset.surveyBodyPath;
@@ -55,11 +55,11 @@ mapMatchedElement(".sort-survey-response", (elem) => {
 
 
 mapMatchedElement(".sort-file-browser", (elem) => {
-    const fileListDataId =elem.dataset.jsonId;
+    const fileListDataId = elem.dataset.jsonId;
     const filesList: FileDescriptionType[] = getDataInElem(fileListDataId, []);
     mount(FileBrowser, {
         target: elem,
-        props: { filesList: filesList, csrf: csrf}
+        props: {filesList: filesList, csrf: csrf}
     });
 });
 
@@ -89,7 +89,6 @@ mapMatchedElement(".sort-richtext-field", (elem) => {
 });
 
 
-
 mapMatchedElement(".sort-response-viewer", (elem) => {
     const csvUrl = elem.dataset.csvUrl ?? "";
     const configId = elem.dataset.jsonConfigId;
@@ -114,10 +113,11 @@ mapMatchedElement(".sort-response-section-viewer", (elem) => {
     const readinessDescriptionsId = elem.dataset.jsonReadinessDescriptionsId;
     const readinessDescriptionsAllSections = getDataInElem(readinessDescriptionsId, []);
     // Readiness descriptions for just this section (levels 0 to 4)
-    const readinessDescriptions = readinessDescriptionsAllSections[sectionIndex-1];
+    const readinessDescriptions = readinessDescriptionsAllSections[sectionIndex - 1];
     const config = getDataInElem(configId, {}) as SurveyConfig;
     const responses: SurveyResponseBatch = getDataInElem(responsesId, []) as [];
     const surveyStats = generateStatsFromSurveyResponses(config, responses);
+    const useBarChart = elem.dataset.useBarChart === 'true'; // Convert string to boolean
     mount(SurveySectionDataView, {
         target: elem,
         props: {
@@ -125,6 +125,7 @@ mapMatchedElement(".sort-response-section-viewer", (elem) => {
             surveyStats: surveyStats,
             sectionIndex: sectionIndex,
             readinessDescriptions: readinessDescriptions,
+            useBarChart: useBarChart,
         }
     });
 });


### PR DESCRIPTION
This is a simpler and smaller results display that may be used on some pages e.g. gather evidence, make improvement plan. The normal histogram is used on the report.

<img width="1140" height="531" alt="image" src="https://github.com/user-attachments/assets/7085c82b-b57a-43a8-889e-b8747bfc9ece" />
