### PR TITLE
Only trigger JS linting for the components dir

### DIFF
--- a/.github/workflows/lint-typescript.yaml
+++ b/.github/workflows/lint-typescript.yaml
@@ -4,8 +4,12 @@ name: Lint & test JavaScript code
 on:
   push:
     branches: [ "dev" ]
+    paths:
+      - ui_components/**
   pull_request:
     branches: [ "dev", "main" ]
+    paths:
+      - ui_components/**
 permissions:
   contents: read
   pull-requests: write  # post coverage reports


### PR DESCRIPTION
This prevents the code coverage report being sent for unrelated code changes.