### PR TITLE
Add all NHS pay bands

### DIFF
--- a/data/survey_config/demography_only_config.json
+++ b/data/survey_config/demography_only_config.json
@@ -50,15 +50,20 @@
         },
         {
           "type": "radio",
-          "label": "What is your current Band/Grade",
+          "label": "What is your current pay band?",
           "required": true,
           "sublabels": [],
           "options": [
+            "Band 2",
+            "Band 3",
             "Band 4",
             "Band 5",
             "Band 6",
             "Band 7",
-            "Band 8",
+            "Band 8a",
+            "Band 8b",
+            "Band 8c",
+            "Band 8d",
             "Band 9"
           ],
           "disabled": false,


### PR DESCRIPTION
Resolves
- https://github.com/RSE-Sheffield/SORT/issues/376

**Changes**

- Added all the available pay bands to the demographics field "What is your current pay band?"

Source: https://www.healthcareers.nhs.uk/working-health/working-nhs/nhs-pay-and-benefits/agenda-change-pay-rates

Band 1 was deprecated in 2018 so I haven't included that (and the users didn't request it.)