### PR TITLE
Remove survey invitation link expiry date

### DIFF
--- a/survey/models.py
+++ b/survey/models.py
@@ -123,7 +123,7 @@ class Survey(models.Model):
 
     def current_invite_token(self):
         for invite in self.invitation_set.all():
-            if not invite.is_expired and not invite.used:
+            if not invite.used:
                 return invite.token
         return None
 
@@ -501,10 +501,6 @@ class Invitation(models.Model):
                 num_token_tries += 1
 
         super().save(*args, **kwargs)
-
-    @property
-    def is_expired(self) -> bool:
-        return timezone.now() > self.created_at + timezone.timedelta(days=7)
 
     @classmethod
     def recipient_list(cls, text: str) -> set[str]:

--- a/survey/templates/survey/error.html
+++ b/survey/templates/survey/error.html
@@ -3,9 +3,7 @@
 {% block content %}
     <div class="error-message">
         <h2>Survey Access Error</h2>
-        {% if error == "This survey link has expired." %}
-            <p>The link you are using to access the survey has expired. Please contact your survey administrator for a new link.</p>
-        {% elif error == "This survey link has already been used." %}
+        {% if error == "This survey link has already been used." %}
             <p>This survey link has already been used. If you believe this is an error, please contact your survey administrator.</p>
         {% else %}
             <p>There was an error processing your request. Please check the link and try again.</p>

--- a/survey/templates/survey/survey.html
+++ b/survey/templates/survey/survey.html
@@ -163,9 +163,7 @@
                             an invitation</a>
 
                     {% else %}
-                        <p>
-                            Geneate an invitation link for your participants to fill in the survey:
-                        </p>
+                        <p>Generate an invitation link for your participants to fill in the survey:</p>
                         <form method="post" action="{% url 'survey_create_invite' survey.id %}">
                             {% csrf_token %}
                             <button type="submit" class="btn btn-primary" name="generate_token"><i

--- a/survey/tests/test_models_invitation.py
+++ b/survey/tests/test_models_invitation.py
@@ -69,29 +69,6 @@ class TestInvitationModel(TestCase):
         invitation.refresh_from_db()
         self.assertTrue(invitation.used)
 
-    def test_is_expired_within_seven_days(self):
-        """Test that an invitation is not expired within 7 days of creation."""
-        invitation = Invitation.objects.create(survey=self.survey)
-        self.assertFalse(invitation.is_expired)
-
-    def test_is_expired_after_seven_days(self):
-        """Test that an invitation is expired after 7 days."""
-        invitation = Invitation.objects.create(survey=self.survey)
-        # Set created_at to 8 days ago
-        past_date = timezone.now() - timezone.timedelta(days=8)
-        invitation.created_at = past_date
-        invitation.save()
-        self.assertTrue(invitation.is_expired)
-
-    def test_is_expired_exactly_seven_days(self):
-        """Test the boundary condition at exactly 7 days."""
-        invitation = Invitation.objects.create(survey=self.survey)
-        # Set created_at to exactly 7 days and 1 second ago
-        past_date = timezone.now() - timezone.timedelta(days=7, seconds=1)
-        invitation.created_at = past_date
-        invitation.save()
-        self.assertTrue(invitation.is_expired)
-
     def test_multiple_invitations_per_survey(self):
         """Test that a survey can have multiple invitations."""
         invitation1 = Invitation.objects.create(survey=self.survey)


### PR DESCRIPTION
**Resolves**
- https://github.com/RSE-Sheffield/SORT/issues/403

**Changes**
- Remove `Invitation.is_expired` property