### PR TITLE
Fix uploads directory permissions

### DIFF
--- a/config/systemd/gunicorn.service
+++ b/config/systemd/gunicorn.service
@@ -6,6 +6,7 @@
 Description=gunicorn service
 Requires=gunicorn.socket
 After=network.target
+Documentation=https://github.com/RSE-Sheffield/SORT/blob/main/docs/deployment.md
 
 [Service]
 # gunicorn can let systemd know when it is ready
@@ -14,11 +15,11 @@ NotifyAccess=main
 # the specific user that our service will run as
 User=gunicorn
 Group=gunicorn
-# this user can be transiently created by systemd
-DynamicUser=true
+# this user is created by the deployment script as a system user
+DynamicUser=false
 RuntimeDirectory=gunicorn
 WorkingDirectory=/opt/sort
-# DJANGO_MEDIA_ROOT
+# path specified in DJANGO_MEDIA_ROOT environment variable
 ReadWritePaths=/srv/www/sort/uploads/
 ExecStart=/opt/sort/venv/bin/gunicorn SORT.wsgi
 ExecReload=/bin/kill -s HUP $MAINPID

--- a/deploy.sh
+++ b/deploy.sh
@@ -36,6 +36,17 @@ python3 -m venv "$venv_dir"
 $pip install --quiet -r requirements.txt
 cp --recursive * "$sort_dir/"
 
+# Create gunicorn system user if it doesn't exist
+if ! id -u gunicorn > /dev/null 2>&1; then
+    useradd --system --no-create-home --shell /bin/false gunicorn
+fi
+
+# Create uploads directory with proper permissions
+# Path configured via DJANGO_MEDIA_ROOT environment variable
+mkdir -p /srv/www/sort/uploads
+chown gunicorn:gunicorn /srv/www/sort/uploads
+chmod 755 /srv/www/sort/uploads
+
 # Create environment file
 sudo touch "$env_file"
 sudo chown gunicorn:gunicorn "$env_file"


### PR DESCRIPTION
Changes:

- Create a system gunicorn user if it doesn't exist
- Create the /srv/www/sort/uploads/ directory and set ownership and permissions
- USe DynamicUser=false for the systemd service (use a real system user instead)

This matches the setup in the production environment (sort-web-app) and fixes the dev VM (sort-web-dev).