### PR TITLE
chore: exclude management commands from coverage scan

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -9,6 +9,8 @@ omit =
     SORT/*
     */admin.py
     */tests/*
+    home/management/*
+    survey/management/*
 
 [report]
 format = markdown


### PR DESCRIPTION
Exclude home/management/ and survey/management/ directories from test coverage reports as these Django management commands are difficult to test comprehensively.