### PR TITLE
fix: commit VERSION file updates from semantic-release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,16 +33,6 @@ jobs:
       - name: Build frontend assets
         run: npm run build
 
-      - name: Create release artifacts
-        run: |
-          mkdir -p release-artifacts
-          # Get version from package.json for artifact naming
-          VERSION=$(node -p "require('./package.json').version")
-          # Include built frontend assets
-          tar -czf release-artifacts/sort-frontend-${VERSION}.tar.gz static/ui-components/
-          # Create source archive with built assets
-          git archive --format=tar.gz --prefix=SORT-${VERSION}/ HEAD > release-artifacts/SORT-${VERSION}.tar.gz
-
       - name: Run semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -51,6 +41,16 @@ jobs:
           GIT_COMMITTER_NAME: github-actions[bot]
           GIT_COMMITTER_EMAIL: github-actions[bot]@users.noreply.github.com
         run: npx semantic-release
+
+      - name: Create release artifacts
+        run: |
+          mkdir -p release-artifacts
+          # Read version written by semantic-release
+          VERSION=$(cat VERSION)
+          # Include built frontend assets
+          tar -czf release-artifacts/sort-frontend-${VERSION}.tar.gz static/ui-components/
+          # Create source archive with built assets
+          git archive --format=tar.gz --prefix=SORT-${VERSION}/ HEAD > release-artifacts/SORT-${VERSION}.tar.gz
 
       - name: Summary
         if: success()

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -40,6 +40,13 @@
       }
     ],
     [
+      "@semantic-release/git",
+      {
+        "assets": ["VERSION", "CHANGELOG.md", "package.json", "package-lock.json"],
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      }
+    ],
+    [
       "@semantic-release/github",
       {
         "assets": [


### PR DESCRIPTION
## Summary

- Adds `@semantic-release/git` plugin to `.releaserc.json` so that the `VERSION`, `CHANGELOG.md`, `package.json`, and `package-lock.json` files updated during the release `prepare` phase are committed back to the repository with a `[skip ci]` commit message
- Moves the "Create release artifacts" workflow step to run **after** `semantic-release`, so artifact filenames use the new version read from `VERSION` (written by `@semantic-release/exec`) rather than the stale version from `package.json`

## Root cause

The `@semantic-release/exec` plugin was writing the new version to the `VERSION` file during `prepare`, but without `@semantic-release/git` in the plugin list, those file changes were never committed back to the repo — leaving `VERSION` perpetually at the old value.

## Test plan

- [ ] Merge a `feat:` or `fix:` commit to `main` and verify the release workflow runs successfully
- [ ] Confirm `VERSION` file in the repository is updated to the new version after the release commit
- [ ] Confirm release artifacts are named with the correct new version

Closes #533

🤖 Generated with [Claude Code](https://claude.com/claude-code)