### PR TITLE
feat: Add several new broader professions

### DIFF
--- a/data/survey_config/demography_only_config_generic.json
+++ b/data/survey_config/demography_only_config_generic.json
@@ -77,6 +77,7 @@
           "options": [
             "Registered Nurse",
             "Registered Midwife",
+            "Medical Practitioner (Doctor/Consultant)",
             "Administrator",
             "Manager",
             "Ambulance Service",
@@ -96,8 +97,15 @@
             "Physiotherapist",
             "Podiatrist",
             "Prosthetist or Orthotist",
+            "Psychologist",
             "Radiographer",
             "Speech and Language Therapist",
+            "Social Worker",
+            "Social Care / Support Worker",
+            "Community, Faith & Third Sector",
+            "Corporate Facilities & Support",
+            "Commissioning / Strategy / Policy Professional",
+            "Advocacy / Advice Worker",
             "Other"
           ],
           "disabled": false,


### PR DESCRIPTION
- Adds `Medical Practitioner (Doctor/Consultant)` to the profession options
- Adds `Psychologist`, `Social Worker`, `Social Care / Support Worker`, `Community, Faith & Third Sector`, `Corporate Facilities & Support`, `Commissioning / Strategy / Policy Professional`, and `Advocacy / Advice Worker` to broaden coverage of NHS and care sector roles