### PR TITLE
fix(nginx): use server_name instead of host header for proxy

### DIFF
--- a/config/nginx/gunicorn.conf
+++ b/config/nginx/gunicorn.conf
@@ -59,7 +59,7 @@ server {
         # https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_set_header
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header Host $host;
+        proxy_set_header Host $server_name;
         # we don't want nginx trying to do something clever with
         # redirects, we set the Host: header above already.
         proxy_redirect off;


### PR DESCRIPTION
## Summary

- Replaces `$host` with `$server_name` in the `proxy_set_header Host` directive in the nginx config
- This fixes a forbidden error at the end of surveys caused by incorrect host header forwarding

## Test plan

- [ ] Complete a survey end-to-end and verify no 403 forbidden error occurs at the final step

🤖 Generated with [Claude Code](https://claude.com/claude-code)