### PR TITLE
fix: forward client Host header to gunicorn using $host

### DIFF
--- a/config/nginx/gunicorn.conf
+++ b/config/nginx/gunicorn.conf
@@ -59,7 +59,7 @@ server {
         # https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_set_header
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header Host $server_name;
+        proxy_set_header Host $host;
         # we don't want nginx trying to do something clever with
         # redirects, we set the Host: header above already.
         proxy_redirect off;


### PR DESCRIPTION
## Summary

- Replaces `$server_name` with `$host` in the nginx `proxy_set_header Host` directive
- `$server_name` was forwarding the hardcoded value `app.sort-online.org` to gunicorn on every server, causing Django's `DisallowedHost` error on the dev machine (see #579)

## Why `$host` is correct

The nginx proxy module docs distinguish three variables:

- **`$server_name`** — the literal `server_name` directive value; never the right choice here
- **`$http_host`** — the raw `Host` header from the client, unparsed
- **`$host`** — the client's `Host` header, normalised (lowercased, port stripped if default); falls back to the matched `server_name` only if the header is absent

`$host` is the value recommended by both the [nginx proxy module documentation](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_set_header) and the [gunicorn deployment guide](https://docs.gunicorn.org/en/stable/deploy.html#nginx-configuration) for forwarding the Host header to upstream WSGI apps.

## Test plan

- [ ] Deploy to dev server and confirm no `DisallowedHost` errors for `sort-web-dev.shef.ac.uk` requests
- [ ] Confirm production (`app.sort-online.org`) continues to work after deploy

Closes #579

🤖 Generated with [Claude Code](https://claude.com/claude-code)