### PR TITLE
fix: show all demographic filters after a disabled field (#598)

### DIFF
--- a/ui_components/src/lib/components/SurveyDemographicFilters.svelte
+++ b/ui_components/src/lib/components/SurveyDemographicFilters.svelte
@@ -49,7 +49,7 @@
           // Hide deactivated fields
           if (fieldConfig.disabled) {
             console.log(`Concealing disabled field "${fieldConfig.label}"`);
-            break;
+            continue;
           }
           switch (fieldConfig.type) {
             case "checkbox":

--- a/ui_components/tests/components/SurveyDemographicFilters.svelte.test.js
+++ b/ui_components/tests/components/SurveyDemographicFilters.svelte.test.js
@@ -1,0 +1,48 @@
+import { test, expect } from "vitest";
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/svelte";
+import SurveyDemographicFilters from "../../src/lib/components/SurveyDemographicFilters.svelte";
+
+// Regression test for the bug where a disabled demographic field caused every
+// field after it to be dropped from the filters (the loop used `break` instead
+// of `continue`). See GitHub issue #598.
+test("SurveyDemographicFilters renders enabled fields after a disabled one", () => {
+  const radioField = (label, options, disabled = false) => ({
+    type: "radio",
+    label,
+    description: "",
+    required: false,
+    sublabels: [],
+    options,
+    disabled,
+    hasOtherOption: false,
+  });
+
+  const config = {
+    sections: [
+      {
+        title: "Demographics",
+        type: "demographic",
+        description: "",
+        fields: [
+          radioField("What is your gender?", ["Male", "Female"]),
+          // Disabled field in the middle — previously caused `break`.
+          radioField("What is your current pay band?", ["Band 5", "Band 6"], true),
+          radioField("What is your profession?", ["Registered Nurse", "Midwife"]),
+        ],
+      },
+    ],
+  };
+
+  // responses[responseIndex][sectionIndex][fieldIndex]
+  const responses = [[["Female", "Band 5", "Registered Nurse"]]];
+
+  render(SurveyDemographicFilters, { props: { config, responses } });
+
+  // Enabled fields before AND after the disabled one must render.
+  expect(screen.getByText("What is your gender?")).toBeInTheDocument();
+  expect(screen.getByText("What is your profession?")).toBeInTheDocument();
+
+  // The disabled field must NOT render.
+  expect(screen.queryByText("What is your current pay band?")).not.toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary

On the survey data views (`survey_report`, `survey_response_data`), the demographic filter dropped every field after the first disabled one — so users saw only age, gender, and working-duration, with **profession** and other fields missing.

## Root cause

In `ui_components/src/lib/components/SurveyDemographicFilters.svelte`, the `onMount` loop that builds the filter list used `break` when it hit a disabled field, terminating the whole field loop. Introduced in commit `fd15e2f` ("Conceal disabled fields…"), where the intent was to *skip* a disabled field, not stop processing.

## Fix

Changed `break` → `continue` (line 52). Now every enabled demographic field gets a filter widget, including profession and any custom fields.

## Testing

- Added `ui_components/tests/components/SurveyDemographicFilters.svelte.test.js` — a regression test with a disabled field flanked by enabled ones. Verified it fails against the old `break` and passes with the fix.
- Full suite: 11/11 test files pass.

Fixes #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)