### PR TITLE
chore: widen NMAHP framing to include wider health and care workforce

### DIFF
--- a/home/templates/about/participant_information.html
+++ b/home/templates/about/participant_information.html
@@ -22,9 +22,9 @@
                     <hr>
                     <h2 class="mt-4 mb-3">What is the project's purpose?</h2>
                     <p>This research aims to understand how NHS and health and care organisations are developing their
-                        research capacity and capability, particularly in nursing, midwifery, and allied health
-                        professions. The SORT survey collects information about your organisation's readiness to support
-                        research activities.</p>
+                        research capacity and capability, including in nursing, midwifery, allied health, and the wider
+                        health and care workforce. The SORT survey collects information about your organisation's
+                        readiness to support research activities.</p>
                     <p>The research will contribute to understanding the organisational factors that support research
                         capability development. Findings will help organisations and system leaders identify best
                         practice approaches and areas for improvement to build research capacity across the NHS and

--- a/home/templates/about/privacy.html
+++ b/home/templates/about/privacy.html
@@ -84,7 +84,7 @@
                                 <td>Consent / Public task</td>
                             </tr>
                             <tr>
-                                <td>To improve research capacity and capability in nursing, midwifery, and allied health professions, in support of the implementation of the Chief Nursing Officer for England's strategy for research.</td>
+                                <td>To improve research capacity and capability in nursing, midwifery, allied health, and the wider health and care workforce, in support of the implementation of the Chief Nursing Officer for England's strategy for research.</td>
                                 <td>Public task / Legitimate interests</td>
                             </tr>
                             <tr>
@@ -104,7 +104,7 @@
 
                     <p>Our legitimate interests include:</p>
                     <ul>
-                        <li><strong>Improving NHS research practice:</strong> Enhancing the capacity of health and care organisations to engage in and support nursing, midwifery, and allied health professional research, leading to improved patient care and healthcare outcomes</li>
+                        <li><strong>Improving NHS research practice:</strong> Enhancing the capacity of health and care organisations to engage in and support research across nursing, midwifery, allied health, and the wider health and care workforce, leading to improved patient care and healthcare outcomes</li>
                         <li><strong>Supporting professional development:</strong> Enabling healthcare professionals to build research skills and integrate evidence-based practice into clinical settings</li>
                         <li><strong>Advancing research capacity development:</strong> Understanding organisational research readiness across the NHS and health and care system to identify best practices and areas for improvement</li>
                         <li><strong>Facilitating evidence-based policy:</strong> Providing data to inform strategic planning and resource allocation for research capacity building in line with national healthcare priorities</li>

--- a/home/templates/help/index.html
+++ b/home/templates/help/index.html
@@ -97,7 +97,7 @@
             <div class="card-body">
                 <p>
                     SORT Online helps healthcare organisations evaluate and strengthen their research capabilities
-                    within nursing, midwifery, and allied health professions.
+                    across nursing, midwifery, allied health, and the wider health and care workforce.
                 </p>
 
                 <h3>First Steps After Login</h3>

--- a/home/templates/home/landing.html
+++ b/home/templates/home/landing.html
@@ -7,8 +7,8 @@
         <h2 class="mb-3">Welcome to SORT Online</h2>
         <p class="text-muted" style="font-size: 0.9rem; line-height: 1.6;">
             The <a href="https://www.sort-online.org/">Self-Assessment of Organisational Readiness Tool</a>
-            helps healthcare organizations evaluate and strengthen their research capabilities within
-            nursing, midwifery, and allied health professions.
+            helps healthcare organizations evaluate and strengthen their research capabilities across
+            nursing, midwifery, allied health, and the wider health and care workforce.
         </p>
     </div>
 

--- a/home/templates/organisation/data_sharing_agreement.html
+++ b/home/templates/organisation/data_sharing_agreement.html
@@ -56,7 +56,7 @@
                         <li><strong>Research use:</strong> contributing to the Recipient Institution's research on research capacity development in healthcare organisations</li>
                     </ul>
 
-                    <p><strong>1.4</strong> The research is conducted under ethics approval and aims to build a national evidence base on research capacity in nursing, midwifery, and allied health professions over a 10-year period.</p>
+                    <p><strong>1.4</strong> The research is conducted under ethics approval and aims to build a national evidence base on research capacity in nursing, midwifery, allied health, and the wider health and care workforce over a 10-year period.</p>
                 </section>
 
                 <section class="mb-5">


### PR DESCRIPTION
## Summary

Closes #602.

Widens the NMAHP framing in participant-facing text so it keeps its nursing, midwifery, and allied health roots while making clear the survey applies to anyone in the **wider health and care workforce** who might respond.

All six occurrences across five templates now read along the lines of *"…nursing, midwifery, allied health, and the wider health and care workforce"*.

## Changed templates

- `home/templates/about/participant_information.html` — the PIS (the issue's primary target)
- `home/templates/about/privacy.html` (2 places)
- `home/templates/help/index.html`
- `home/templates/home/landing.html`
- `home/templates/organisation/data_sharing_agreement.html`

## Testing

Django's system check passes. Changes are wording-only in templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)