### PR TITLE
fix: show email as fallback link text for unnamed users in console user list

### DIFF
--- a/home/templates/console/users.html
+++ b/home/templates/console/users.html
@@ -18,7 +18,7 @@
                     <tbody>
                     {% for user in users %}
                         <tr>
-                            <td><a href="{% url 'admin_user_detail' user.pk %}">{{ user.first_name }} {{ user.last_name }}</a></td>
+                            <td><a href="{% url 'admin_user_detail' user.pk %}">{{ user.get_full_name|default:user.email }}</a></td>
                             <td>{{ user.email }}</td>
                             <td>{{ user.organisationmembership_set.count }}</td>
                             <td class="text-muted">{{ user.date_joined|date:"d M Y" }}</td>


### PR DESCRIPTION
## Summary

- Fixes invisible/unclickable detail link for users who have no first or last name set on `/console/users/`
- Uses `get_full_name|default:user.email` so named users display their name and unnamed users display their email address

Closes #612

## Test plan

- [ ] Visit `/console/users/` with at least one user who has no name set — confirm their row shows the email as a clickable link
- [ ] Confirm clicking the link navigates to the correct user detail page
- [ ] Confirm users with a name still display their full name as the link text

🤖 Generated with [Claude Code](https://claude.com/claude-code)