### PR TITLE
chore: update to Node 22 LTS (#220)

### DIFF
--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: NPM audit

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Prerequisites, ensure the following are already installed on your system:
 
 - Python (the version is defined [.python-version](./.python-version))
 - pip
-- Nodejs (20.x)
+- Nodejs (22.x)
 ---
 
 1. Clone the project repository to your local machine

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "vitest": "^3.2.4"
       },
       "engines": {
-        "node": ">=20 <21"
+        "node": ">=22 <23"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "type": "module",
   "engines": {
-    "node": ">=20 <21"
+    "node": ">=22 <23"
   },
   "scripts": {
     "dev": "vite",

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -20,7 +20,7 @@ pip="$venv_dir/bin/pip"
 python_version="python$(cat .python-version | xargs)"
 python="$venv_dir/bin/python"
 env_file="$sort_dir/.env"
-node_version=20
+node_version=22
 django_media_root="/srv/www/sort/uploads/"
 
 # Install British UTF-8 locale so we can use this with PostgreSQL.

--- a/ui_components/README.md
+++ b/ui_components/README.md
@@ -4,7 +4,7 @@ UI Components for the SORT application
 
 ## Dependencies
 
-- nodejs (20.x)
+- nodejs (22.x)
 - vite
 - svelte
 - bootstrap


### PR DESCRIPTION
Closes #220

## Summary

Node 20 has entered maintenance and Node 22 is now the active LTS. The previous incompatibility with certain dependencies (the reason we stayed on Node 20) is resolved following the Vite 6 / Svelte 5 / Vitest 3 toolchain upgrades.

This updates every Node version pin from 20 → 22:

| File | Change |
|------|--------|
| `package.json` | `engines.node`: `>=20 <21` → `>=22 <23` |
| `package-lock.json` | embedded `engines` pin regenerated to match |
| `.github/workflows/npm-audit-fix.yml` | `node-version: '20'` → `'22'` |
| `scripts/deploy.sh` | `node_version=20` → `22` |
| `README.md` | `Nodejs (20.x)` → `(22.x)` |
| `ui_components/README.md` | `nodejs (20.x)` → `(22.x)` |

The `release.yaml`, `lint-typescript.yaml`, and `django-check.yaml` workflows use `node-version-file: package.json`, so they pick up Node 22 automatically — no edits needed.

## Verification

All run on Node v22.21.0:

- ✅ `npm install` — no engine-incompatibility errors; lockfile pin updated cleanly
- ✅ `npm run build` — Vite build succeeded, manifest regenerated
- ✅ `npm test` — 11/11 vitest files passed
- ✅ `python manage.py test home/tests survey/tests --parallel=auto` — 138 passed (6 skipped)

`npm run check` reports pre-existing svelte-check/tsc errors that are unrelated to this change (confirmed identical with the change stashed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)