### PR TITLE
feat: add CSRF failure view with logging for survey submission (#623)

### DIFF
--- a/SORT/settings.py
+++ b/SORT/settings.py
@@ -256,6 +256,10 @@ SESSION_COOKIE_SECURE = cast_to_boolean(
 )
 CSRF_COOKIE_SECURE = cast_to_boolean(os.getenv("DJANGO_CSRF_COOKIE_SECURE", not DEBUG))
 
+# Custom view rendered when CSRF verification fails (issue #623).
+# Renders a friendly retry page and logs the failure (see SORT/views.py).
+CSRF_FAILURE_VIEW = "SORT.views.csrf_failure"
+
 # Logging
 # https://docs.djangoproject.com/en/5.1/topics/logging/
 LOGGING = {

--- a/SORT/views.py
+++ b/SORT/views.py
@@ -1,0 +1,34 @@
+"""Project-level views for the SORT project."""
+
+import logging
+
+from django.conf import settings
+from django.shortcuts import render
+
+logger = logging.getLogger(__name__)
+
+
+def csrf_failure(request, reason=""):
+    """
+    Custom ``CSRF_FAILURE_VIEW`` (see ``settings.CSRF_FAILURE_VIEW``).
+
+    Renders a friendly retry page instead of Django's raw 403, and logs the
+    failure so CSRF 403s can be measured in production (investigating #599/#623).
+
+    We log whether the CSRF cookie reached the server rather than the token
+    value itself: the cookie presence is the most diagnostic signal for the
+    cookie-blocking / Secure-cookie theory, and logging secret token values is
+    poor practice.
+    """
+    logger.warning(
+        "CSRF verification failed: reason=%r path=%s method=%s "
+        "csrf_cookie_present=%s referer=%r user_agent=%r",
+        reason,
+        request.path,
+        request.method,
+        "csrftoken" in request.COOKIES,
+        request.META.get("HTTP_REFERER"),
+        request.META.get("HTTP_USER_AGENT"),
+    )
+    context = {"reason": reason, "debug": settings.DEBUG}
+    return render(request, "csrf_failure.html", context, status=403)

--- a/home/tests/test_csrf_failure.py
+++ b/home/tests/test_csrf_failure.py
@@ -1,0 +1,39 @@
+from http import HTTPStatus
+
+from django.contrib.auth.models import AnonymousUser
+from django.test import RequestFactory, TestCase
+
+from SORT.views import csrf_failure
+
+
+class CsrfFailureViewTestCase(TestCase):
+    """Tests for the custom CSRF_FAILURE_VIEW (issue #623)."""
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def _make_request(self):
+        request = self.factory.post("/survey_response/some-token")
+        request.user = AnonymousUser()
+        return request
+
+    def test_renders_friendly_403(self):
+        """The view renders the friendly retry page with a 403 status."""
+        response = csrf_failure(self._make_request(), reason="REASON_NO_CSRF_COOKIE")
+
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
+        content = response.content.decode()
+        self.assertIn("your submission could not be completed", content)
+        # Django's raw CSRF page wording must not leak to participants.
+        self.assertNotIn("CSRF verification failed", content)
+
+    def test_logs_the_failure(self):
+        """The view logs a warning including the reason and request path."""
+        with self.assertLogs("SORT.views", level="WARNING") as cm:
+            csrf_failure(self._make_request(), reason="REASON_NO_CSRF_COOKIE")
+
+        self.assertEqual(len(cm.records), 1)
+        message = cm.records[0].getMessage()
+        self.assertIn("REASON_NO_CSRF_COOKIE", message)
+        self.assertIn("/survey_response/some-token", message)
+        self.assertIn("csrf_cookie_present=False", message)

--- a/static/templates/csrf_failure.html
+++ b/static/templates/csrf_failure.html
@@ -1,0 +1,20 @@
+{% extends "base_anonymous.html" %}
+
+{% block content %}
+    <div class="container mb-3">
+        <h3>Sorry, your submission could not be completed</h3>
+
+        <div class="alert alert-warning" role="alert">
+            <p>Your session could not be verified, so your answers were not submitted.
+               This usually happens when cookies are disabled or the page was left open
+               for a long time.</p>
+            <p>To try again:</p>
+            <ul>
+                <li>Make sure cookies are enabled in your browser.</li>
+                <li>Reopen the survey using the original link and resubmit.</li>
+            </ul>
+        </div>
+
+        {% if reason and debug %}<p class="text-muted small">Reason: {{ reason }}</p>{% endif %}
+    </div>
+{% endblock %}


### PR DESCRIPTION
## Summary

Adds a custom `CSRF_FAILURE_VIEW` so CSRF verification failures no longer show participants Django's raw "Forbidden (403) — CSRF verification failed" page, and are logged for the first time.

This is the leading suspect for the intermittent survey-submission errors in #599: the participant submit path posts `csrfmiddlewaretoken` (`SurveyResponseComponent.svelte:93`), `CsrfViewMiddleware` is enabled, and in production the `csrftoken` cookie is `Secure`. Participants who block/clear cookies, use private mode, hit strict mobile browsers (Safari ITP), or reach the page over plain HTTP fail verification — none of which reproduces on a normal desktop browser, and none of which was previously logged.

## Changes

- **`SORT/views.py`** (new): `csrf_failure(request, reason="")` logs each failure at `WARNING` (reason, path, method, whether the `csrftoken` cookie reached the server, referer, user-agent), then renders a friendly 403 page. Logs cookie *presence* rather than the raw token value — same diagnostic signal for the cookie-blocking theory, without writing a secret to logs.
- **`static/templates/csrf_failure.html`** (new): participant-facing page extending `base_anonymous.html` with retry guidance (enable cookies / reopen the link). The raw reason is only shown under `DEBUG`.
- **`SORT/settings.py`**: registers `CSRF_FAILURE_VIEW = "SORT.views.csrf_failure"`.
- **`home/tests/test_csrf_failure.py`** (new): verifies the friendly 403 renders (and Django's raw wording does not leak) and that the warning log includes the reason, path, and cookie presence.

## Why

Turns a vague, unreproducible bug report into actionable telemetry, and stops affected participants from seeing a raw Django error page.

Closes #623. Related: #599.

## Verification

- `python manage.py test home.tests.test_csrf_failure` → 2 passed
- `python manage.py check` → no issues
- `flake8` / `black --check` / `isort --check-only` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)