### PR TITLE
chore: add error handling and logging around survey submission processing

### DIFF
--- a/survey/templates/survey/survey_response_submission_error.html
+++ b/survey/templates/survey/survey_response_submission_error.html
@@ -1,0 +1,10 @@
+{% extends 'base_manager.html' %}
+{% block content %}
+<div class="container">
+    <h3>Survey submission error</h3>
+    <p>
+        There was a problem saving your response. Please try again, or contact
+        the survey administrator if the problem persists.
+    </p>
+</div>
+{% endblock %}

--- a/survey/tests/test_survey_views.py
+++ b/survey/tests/test_survey_views.py
@@ -1,6 +1,8 @@
 import json
 from http import HTTPStatus
+from unittest.mock import patch
 
+import django.urls
 import SORT.test.model_factory
 import SORT.test.test_case
 from survey.models import Invitation
@@ -91,7 +93,34 @@ class SurveyViewTestCase(SORT.test.test_case.ViewTestCase):
 
     def test_survey_response_post(self):
         invitation = Invitation.objects.create(survey=self.survey)
-        self.post("survey_response", token=invitation.token)
+        self.post(
+            "survey_response",
+            token=invitation.token,
+            data={"value": json.dumps({})},
+            expected_status_code=HTTPStatus.FOUND,
+        )
+
+    def test_survey_response_post_missing_value(self):
+        invitation = Invitation.objects.create(survey=self.survey)
+        url = django.urls.reverse("survey_response", kwargs={"token": invitation.token})
+        response = self.client.post(url, data={})
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+        self.assertTemplateUsed(response, "survey/survey_response_submission_error.html")
+
+    def test_survey_response_post_invalid_json(self):
+        invitation = Invitation.objects.create(survey=self.survey)
+        url = django.urls.reverse("survey_response", kwargs={"token": invitation.token})
+        response = self.client.post(url, data={"value": "not-valid-json"})
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+        self.assertTemplateUsed(response, "survey/survey_response_submission_error.html")
+
+    def test_survey_response_post_service_error(self):
+        invitation = Invitation.objects.create(survey=self.survey)
+        url = django.urls.reverse("survey_response", kwargs={"token": invitation.token})
+        with patch("survey.views.survey_service.accept_response", side_effect=Exception("db error")):
+            response = self.client.post(url, data={"value": json.dumps({})})
+        self.assertEqual(response.status_code, HTTPStatus.INTERNAL_SERVER_ERROR)
+        self.assertTemplateUsed(response, "survey/survey_response_submission_error.html")
 
     def test_survey_link_invalid(self):
         self.get("survey_link_invalid")

--- a/survey/views.py
+++ b/survey/views.py
@@ -500,14 +500,44 @@ class SurveyResponseView(View):
             context = dict()
 
             if is_post:
-                # Only process if it's a post request
+                if "value" not in request.POST:
+                    logger.error(
+                        "Survey submission missing 'value' field: token=%s survey_id=%s",
+                        token, survey.pk,
+                    )
+                    return render(
+                        request,
+                        "survey/survey_response_submission_error.html",
+                        status=400,
+                    )
 
-                # TODO: Server side value validation to make sure
-                if "value" in request.POST:
-                    responseValues = json.loads(request.POST.get("value", None))
+                try:
+                    responseValues = json.loads(request.POST["value"])
+                except json.JSONDecodeError:
+                    logger.error(
+                        "Survey submission contained invalid JSON: token=%s survey_id=%s",
+                        token, survey.pk,
+                    )
+                    return render(
+                        request,
+                        "survey/survey_response_submission_error.html",
+                        status=400,
+                    )
+
+                try:
                     survey_service.accept_response(survey, responseValues)
-                    context["value"] = responseValues
-                    return redirect("completion_page")
+                except Exception:
+                    logger.exception(
+                        "Failed to save survey response: token=%s survey_id=%s",
+                        token, survey.pk,
+                    )
+                    return render(
+                        request,
+                        "survey/survey_response_submission_error.html",
+                        status=500,
+                    )
+
+                return redirect("completion_page")
 
             context["survey"] = survey
             context["csrf"] = str(csrf(self.request)["csrf_token"])


### PR DESCRIPTION
## Summary

- Wraps the `SurveyResponseView` POST handler in explicit error handling covering three previously unhandled failure modes: missing `value` field, malformed JSON, and service/DB exceptions
- Logs each failure at ERROR level with `token` and `survey_id` for incident correlation
- Renders a new participant-facing error template (`survey_response_submission_error.html`) instead of returning a raw 500 or silently re-rendering
- Updates the existing `test_survey_response_post` smoke test (it previously expected 200 on a no-value POST; now correctly expects 302 on a valid submission) and adds three new targeted tests

Closes #624

🤖 Generated with [Claude Code](https://claude.com/claude-code)