### PR TITLE
fix: log SMTP errors and increase email timeout

### DIFF
--- a/SORT/settings.py
+++ b/SORT/settings.py
@@ -206,7 +206,7 @@ EMAIL_HOST_USER = os.getenv("DJANGO_EMAIL_HOST_USER")
 EMAIL_HOST_PASSWORD = os.getenv("DJANGO_EMAIL_HOST_PASSWORD")
 EMAIL_USE_TLS = cast_to_boolean(os.getenv("DJANGO_EMAIL_USE_TLS", False))
 EMAIL_USE_SSL = cast_to_boolean(os.getenv("DJANGO_EMAIL_USE_SSL", True))
-EMAIL_TIMEOUT = int(os.getenv("DJANGO_EMAIL_TIMEOUT", 3))
+EMAIL_TIMEOUT = int(os.getenv("DJANGO_EMAIL_TIMEOUT", 30))
 EMAIL_SSL_KEYFILE = os.getenv("DJANGO_EMAIL_SSL_KEYFILE")
 EMAIL_SSL_CERTFILE = os.getenv("DJANGO_EMAIL_SSL_CERTFILE")
 EMAIL_SUBJECT_PREFIX = os.getenv("DJANGO_EMAIL_SUBJECT_PREFIX", "[SORT] ")
@@ -320,6 +320,7 @@ INVITATIONS_EMAIL_SUBJECT_PREFIX = "SORT"
 
 # AllAuth authentication options
 # https://docs.allauth.org/en/latest/account/configuration.html
+ACCOUNT_ADAPTER = "home.adapter.AccountAdapter"
 ACCOUNT_SIGNUP_FIELDS = ["email*", "password1*", "password2*"]
 ACCOUNT_LOGIN_METHODS = {"email"}
 ACCOUNT_USER_MODEL_USERNAME_FIELD = None

--- a/home/adapter.py
+++ b/home/adapter.py
@@ -1,0 +1,17 @@
+import logging
+import smtplib
+
+from allauth.account.adapter import DefaultAccountAdapter
+
+logger = logging.getLogger(__name__)
+
+
+class AccountAdapter(DefaultAccountAdapter):
+    def send_mail(self, template_prefix, email, context):
+        try:
+            super().send_mail(template_prefix, email, context)
+        except (smtplib.SMTPException, OSError):
+            logger.exception(
+                "Failed to send email (template=%s, to=%s)", template_prefix, email
+            )
+            raise


### PR DESCRIPTION
Closes #638.

## Summary

- Increase default `EMAIL_TIMEOUT` from 3 s to 30 s — the previous value was too short for an SSL SMTP session (TCP + TLS handshake + EHLO/AUTH + DATA acknowledgement), causing spurious `SMTPServerDisconnected` / `TimeoutError` errors under any SMTP latency
- Add a custom allauth `AccountAdapter` (`home/adapter.py`) that catches `SMTPException` and `OSError` in `send_mail`, logs them at `ERROR` level with full stack trace, then re-raises — making failures visible in the application log rather than only in Django's 500 handler
- Register the adapter via `ACCOUNT_ADAPTER` in settings

The environment variable `DJANGO_EMAIL_TIMEOUT` can still override the default if a different timeout is required for a specific deployment.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)