### PR TITLE
feat: show success or abort message when deploy.sh exits

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -23,6 +23,16 @@ env_file="$sort_dir/.env"
 node_version=22
 django_media_root="/srv/www/sort/uploads/"
 
+finish() {
+    local exit_code=$?
+    if [ "$exit_code" -eq 0 ]; then
+        echo "Deployment completed successfully."
+    else
+        echo "Deployment aborted (exit code: $exit_code)."
+    fi
+}
+trap finish EXIT
+
 # Install British UTF-8 locale so we can use this with PostgreSQL.
 # This is important to avoid the limitations of the LATIN1 character set.
 sudo locale-gen en_GB


### PR DESCRIPTION
## Summary

- Adds a `finish()` function with a `trap finish EXIT` near the top of `scripts/deploy.sh`
- Prints `Deployment completed successfully.` on clean exit, or `Deployment aborted (exit code: N).` when `set -e` triggers an early exit
- Uses `trap EXIT` rather than `trap ERR` so the message fires reliably even from within subshells (the script uses several `(cd ... && ...)` subshells)

## Test plan

- [ ] Introduce a deliberate failing command early in the script and confirm the abort message appears with the correct exit code
- [ ] Run the full script to completion and confirm the success message appears at the end

🤖 Generated with [Claude Code](https://claude.com/claude-code)