### PR TITLE
fix: remove invalid EnvironmentFile= from gunicorn.service

### DIFF
--- a/config/systemd/gunicorn.service
+++ b/config/systemd/gunicorn.service
@@ -33,7 +33,6 @@ MemoryDenyWriteExecute=yes
 NoNewPrivileges=yes
 # https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#Credentials
 LoadCredential=.env:/opt/sort/.env
-EnvironmentFile=${CREDENTIALS_DIRECTORY}/.env
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

- Removes `EnvironmentFile=${CREDENTIALS_DIRECTORY}/.env` from `config/systemd/gunicorn.service`

systemd does **not** expand environment variables in `EnvironmentFile=` directive values — only literal absolute paths are accepted. The line was silently ignored with the repeated journal warning reported in #639.

The line is redundant anyway: `LoadCredential=.env:/opt/sort/.env` already copies the file into systemd's credentials directory and exposes `CREDENTIALS_DIRECTORY` as an environment variable. Django's `settings.py` then calls `load_dotenv()` using that path, so all `.env` values reach the process regardless.

Fixes #639

## Test plan

- [ ] Deploy updated unit to the server, run `sudo systemctl daemon-reload && sudo systemctl restart gunicorn`
- [ ] Confirm no `EnvironmentFile= path is not absolute` lines in `journalctl -u gunicorn --since "1 minute ago"`
- [ ] Confirm app boots and serves requests normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)