### PR TITLE
fix: remove redundant .env sourcing in deploy.sh

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -220,20 +220,17 @@ fi
 # Run deployment checks
 echo "Checking Django system..."
 # https://docs.djangoproject.com/en/5.1/howto/deployment/checklist/
-# shellcheck source=/opt/sort/.env
-(cd "$sort_dir" && set -a && source "$env_file" && set +a && $python manage.py check --deploy --fail-level WARNING)
+(cd "$sort_dir" && $python manage.py check --deploy --fail-level WARNING)
 
 # Check for missing migrations
 # https://docs.djangoproject.com/en/5.1/ref/django-admin/#cmdoption-makemigrations-check
 echo "Checking for missing migrations..."
-# shellcheck source=/opt/sort/.env
-(cd "$sort_dir" && set -a && source "$env_file" && set +a && $python manage.py makemigrations --check --dry-run)
+(cd "$sort_dir" && $python manage.py makemigrations --check --dry-run)
 
 # Migrate database changes
 # https://docs.djangoproject.com/en/5.1/topics/migrations/
 echo "Applying Django migrations..."
-# shellcheck source=/opt/sort/.env
-(cd "$sort_dir" && set -a && source "$env_file" && set +a && $python manage.py migrate)
+(cd "$sort_dir" && $python manage.py migrate)
 
 echo "Restarting web application service..."
 systemctl restart gunicorn.service


### PR DESCRIPTION
## Summary

- `scripts/deploy.sh` was using `set -a && source "$env_file" && set +a` before each `manage.py` invocation to load the `.env` file into the shell environment
- When the `.env` file contains values that aren't valid bash syntax (e.g. a bare IP address in `DJANGO_ALLOWED_HOSTS`), bash prints `/opt/sort/.env: line N: 143.167.1.250: command not found`
- This was redundant: `SORT/settings.py` already calls `load_dotenv()` via python-dotenv at startup, which reads `/opt/sort/.env` directly (resolved from the CWD set by `cd "$sort_dir"`)
- Removed the three `source` calls and their now-unnecessary `shellcheck` directives

Closes #644

## Test plan

- [ ] Run `sudo bash scripts/deploy.sh` on a server with an `.env` containing IP addresses
- [ ] Confirm no `command not found` lines appear in the output
- [ ] Confirm `check --deploy`, `makemigrations --check`, and `migrate` still succeed
- [ ] Confirm "Deployment completed successfully." is printed

🤖 Generated with [Claude Code](https://claude.com/claude-code)