### PR TITLE
chore: add required asterisk to signup checkbox label

### DIFF
--- a/home/templates/home/register.html
+++ b/home/templates/home/register.html
@@ -45,6 +45,7 @@
             <input class="form-check-input" type="checkbox" id="is_manager" name="is_manager" required>
             <label class="form-check-label" for="is_manager">
                 I confirm I am signing up to SORT as an account manager.
+                <span class="text-danger" aria-hidden="true">*</span>
             </label>
         </div>
 

--- a/static/templates/account/signup.html
+++ b/static/templates/account/signup.html
@@ -29,6 +29,7 @@
             <input class="form-check-input" type="checkbox" id="is_manager" name="is_manager" required>
             <label class="form-check-label" for="is_manager">
                 I confirm I am signing up to SORT as an account manager.
+                <span class="text-danger" aria-hidden="true">*</span>
             </label>
         </div>
 


### PR DESCRIPTION
## Summary

- Adds a red `*` after the "I confirm I am signing up to SORT as an account manager." checkbox label on the signup form
- Uses Bootstrap's `text-danger` class — no new CSS required
- `aria-hidden="true"` prevents screen readers from announcing "asterisk" (the `required` attribute already conveys mandatory status to assistive tech)
- Applied to both signup templates: `home/templates/home/register.html` and `static/templates/account/signup.html`

## Test plan

- [ ] Visit a signup invite URL (`/signup/<key>/`) and confirm a red `*` appears next to the checkbox label
- [ ] Submit the form without ticking the box — browser validation still blocks submission
- [ ] No visual regressions on the rest of the form

🤖 Generated with [Claude Code](https://claude.com/claude-code)