### PR TITLE
fix: guard against undici GHSA-p88m-4jfj-68fv / CVE-2026-9679

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,9 @@
     "vite": "^6.0.5",
     "vitest": "^3.2.4"
   },
+  "overrides": {
+    "undici": ">=6.27.0"
+  },
   "dependencies": {
     "axios": "^1.13.5",
     "chart.js": "^4.4.8",


### PR DESCRIPTION
## Summary

Addresses Dependabot alert #148 — undici HTTP header injection via `Set-Cookie` percent-decoding (GHSA-p88m-4jfj-68fv / CVE-2026-9679, CVSS 5.9 medium).

Adds an `overrides` entry in `package.json` that pins any non-bundled resolution of `undici` to `>=6.27.0`, preventing future regressions.

## Dependency state

| Location | Version | Status |
|---|---|---|
| `node_modules/undici` | 7.28.0 | ✅ patched |
| `node_modules/@actions/http-client/node_modules/undici` | 6.27.0 | ✅ patched |
| `node_modules/npm/node_modules/undici` | 6.26.0 | ⚠️ see below |

## Known limitation

The remaining instance (`node_modules/npm/node_modules/undici@6.26.0`) is a **bundled dependency** packaged inside `npm@11.17.0` (pulled in transitively by `@semantic-release/npm`). npm's override mechanism [cannot affect bundled deps](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#overrides) — they are embedded in the tarball. There is no stable npm@11.x release that ships a patched undici yet (latest is 11.17.0, released 2026-06-11, before the CVE was published 2026-06-19).

**Risk**: All affected packages are dev-only dependencies used only during CI/CD. The vulnerable `parseSetCookie` code path requires npm to receive a malicious `Set-Cookie` header from an attacker-controlled npm registry and forward it — practical exploit surface is negligible.

**Follow-up**: Once npm releases a patch (11.17.1 or 11.18.0), adding `"npm": "^11.17.1"` to `overrides` or bumping `@semantic-release/npm` will close this fully.

## Test plan

- [x] `npm test` — 16/16 tests pass
- [x] `npm audit` — confirms no new vulnerabilities introduced

Closes #148 (partially — bundled dep requires upstream npm fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)