### PR TITLE
fix: include JSON path in survey response validation errors

### DIFF
--- a/survey/models.py
+++ b/survey/models.py
@@ -511,7 +511,7 @@ class SurveyResponse(models.Model):
         try:
             jsonschema.validate(self.answers, self.survey.response_schema)
         except jsonschema.ValidationError as exc:
-            raise ValidationError(exc.message) from exc
+            raise ValidationError(f"{exc.json_path}: {exc.message}") from exc
 
     def clean(self):
         super().clean()

--- a/survey/models.py
+++ b/survey/models.py
@@ -188,6 +188,30 @@ class Survey(models.Model):
         # survey_config field
         return tuple(self.survey_config["sections"])
 
+    def describe_error_path(self, path) -> str:
+        """
+        Turn a response_schema validation error path (section index, field index,
+        and for likert fields a sublabel index) into a human-readable location,
+        using this survey's section titles and field labels.
+        """
+        path = list(path)
+        if not path:
+            return "Response"
+
+        section = self.sections[path[0]]
+        description = f"Section {path[0] + 1} '{section.get('title', path[0] + 1)}'"
+        if len(path) == 1:
+            return description
+
+        field = section["fields"][path[1]]
+        description += f", field '{field.get('label', path[1] + 1)}'"
+
+        sublabels = field.get("sublabels", [])
+        if len(path) > 2 and field.get("type") == "likert" and path[2] < len(sublabels):
+            description += f" ('{sublabels[path[2]]}')"
+
+        return description
+
     @cached_property
     def response_schema(self) -> dict:
         """
@@ -505,13 +529,22 @@ class SurveyResponse(models.Model):
         """
         Validate response answers against this survey's JSON Schema.
 
-        Raises django.core.exceptions.ValidationError if the answers do not match.
+        Raises django.core.exceptions.ValidationError, with one message per
+        failing field, if the answers do not match.
         """
-
-        try:
-            jsonschema.validate(self.answers, self.survey.response_schema)
-        except jsonschema.ValidationError as exc:
-            raise ValidationError(f"{exc.json_path}: {exc.message}") from exc
+        schema = self.survey.response_schema
+        validator_cls = jsonschema.validators.validator_for(schema)
+        errors = sorted(
+            validator_cls(schema).iter_errors(self.answers),
+            key=lambda exc: list(exc.absolute_path),
+        )
+        if errors:
+            raise ValidationError(
+                [
+                    f"{self.survey.describe_error_path(exc.absolute_path)}: {exc.message}"
+                    for exc in errors
+                ]
+            )
 
     def clean(self):
         super().clean()

--- a/survey/tests/test_schema.py
+++ b/survey/tests/test_schema.py
@@ -478,6 +478,65 @@ class TestSurveyResponseValidate(TestCase):
             # error class; .validate() must convert it.
             jsonschema.validate(response.answers, survey.response_schema)
 
+    # --- multiple errors and friendly labels ---
+
+    def test_validate_reports_every_failing_field(self):
+        survey = self._make_survey([
+            {
+                "fields": [
+                    {"type": "radio", "options": ["Yes", "No"]},
+                    {"type": "radio", "options": ["Yes", "No"]},
+                ]
+            }
+        ])
+        response = self._response(survey, [["Maybe", "Nope"]])
+        with self.assertRaises(ValidationError) as context:
+            response.validate()
+        self.assertEqual(len(context.exception.messages), 2)
+
+    def test_validate_error_message_includes_section_and_field_label(self):
+        survey = self._make_survey([
+            {
+                "title": "Consent",
+                "fields": [{"type": "radio", "label": "Do you agree?", "options": ["Yes", "No"]}],
+            }
+        ])
+        response = self._response(survey, [["Maybe"]])
+        with self.assertRaises(ValidationError) as context:
+            response.validate()
+        message = context.exception.messages[0]
+        self.assertIn("Consent", message)
+        self.assertIn("Do you agree?", message)
+
+    def test_validate_error_message_includes_likert_sublabel(self):
+        survey = self._make_survey([
+            {
+                "title": "Ratings",
+                "fields": [
+                    {
+                        "type": "likert",
+                        "label": "Rate these",
+                        "sublabels": ["First statement", "Second statement"],
+                        "options": ["0", "1"],
+                    }
+                ],
+            }
+        ])
+        response = self._response(survey, [[["0", "invalid"]]])
+        with self.assertRaises(ValidationError) as context:
+            response.validate()
+        message = context.exception.messages[0]
+        self.assertIn("Second statement", message)
+
+    def test_validate_error_falls_back_when_title_and_label_missing(self):
+        survey = self._make_survey([
+            {"fields": [{"type": "radio", "options": ["Yes", "No"]}]}
+        ])
+        response = self._response(survey, [["Maybe"]])
+        with self.assertRaises(ValidationError) as context:
+            response.validate()  # Should not raise KeyError
+        self.assertEqual(len(context.exception.messages), 1)
+
     # --- validate() vs clean() and inactive survey ---
 
     def test_validate_does_not_check_inactive_survey(self):


### PR DESCRIPTION
## Summary
- `SurveyResponse.validate()` now collects *every* schema validation failure in a response's answers (via `iter_errors`) instead of stopping at the first one, raising a `ValidationError` with one message per failing field.
- Each message describes the failing field using the survey's own section titles and field labels (e.g. `Section 2 'Data management', field 'Do you have a data plan?'`), including the likert sublabel when relevant, via the new `Survey.describe_error_path()` helper — falling back gracefully when a title/label is missing.
- This replaces the raw JSON path (e.g. `$[2][0]`) from the previous iteration with a human-readable location, making `validate_responses` output easy to act on without cross-referencing the schema.

## Test plan
- [x] `python manage.py test survey.tests.test_schema --parallel=auto --failfast` passes
