### PR TITLE
fix: authenticate semantic-release with a PAT so release-to-orda.yml can fire

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,10 @@ jobs:
 
       - name: Run semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # A PAT is required, not secrets.GITHUB_TOKEN: GitHub does not cascade
+          # the release: published event to other workflows (e.g. release-to-orda.yml)
+          # when the release was created by the default token. See docs/publish.md.
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: npx semantic-release
 
       - name: Create release artifacts

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -34,4 +34,6 @@ Go to **Actions → Create Release → Run workflow**. Useful for re-running a f
 
 **No release created** — check that at least one commit since the last tag uses a release-triggering type (`feat:`, `fix:`, etc.).
 
-**semantic-release fails** — check the Actions log for build errors or `GITHUB_TOKEN` permission issues.
+**semantic-release fails** — check the Actions log for build errors or `RELEASE_TOKEN` permission issues.
+
+**Release created but nothing archived to ORDA** — `release.yaml` authenticates with `secrets.RELEASE_TOKEN` (a PAT), not `secrets.GITHUB_TOKEN`, specifically because GitHub won't cascade the `release: published` event to other workflows (like `release-to-orda.yml`) when the release was created by the default token. If `RELEASE_TOKEN` is missing or expired, releases still get created but `release-to-orda.yml` silently never runs. See [docs/publish.md](docs/publish.md#one-time-setup-release-token).

--- a/docs/publish.md
+++ b/docs/publish.md
@@ -8,7 +8,7 @@ This guide covers the end-to-end flow for releasing SORT and archiving it to [OR
 Merge to main
      │
      ▼
-release.yaml (semantic-release)
+release.yaml (semantic-release, authenticated with RELEASE_TOKEN)
   • bumps version
   • builds frontend
   • creates GitHub Release with artifacts
@@ -21,6 +21,17 @@ release-to-orda.yml (triggered by GitHub Release)
      ▼
 ORDA mints / updates DOI
 ```
+
+---
+
+## One-time setup: release token
+
+`release-to-orda.yml` listens for the `release: published` event. GitHub does not deliver that event to other workflows when the release was created using the default `secrets.GITHUB_TOKEN` — this is an intentional anti-recursion safeguard, not a bug. Since `release.yaml` creates the release via `npx semantic-release`, it must authenticate with a different token or `release-to-orda.yml` will simply never run (silently — the pipeline looks fine, no DOI ever gets minted).
+
+1. Create a fine-grained personal access token (or use a dedicated bot/service account) scoped to the `RSE-Sheffield/SORT` repository with **Contents: Read and write** permission.
+2. Add it to the repository as secret **`RELEASE_TOKEN`** (**Settings → Secrets and variables → Actions**).
+
+This is required for the release pipeline to trigger `release-to-orda.yml` at all, independent of the ORDA-specific setup below.
 
 ---
 


### PR DESCRIPTION
## Summary

- `release-to-orda.yml` has never run, despite ~20 releases (v0.12.0 → v0.20.0) publishing successfully, and `FIGSHARE_ARTICLE_ID`/`FIGSHARE_TOKEN` already being configured.
- Root cause: GitHub does **not** deliver the `release: published` event to other workflows when the release was created using the default `secrets.GITHUB_TOKEN` — an intentional anti-recursion safeguard. `release.yaml` creates the release via `npx semantic-release` authenticated with `secrets.GITHUB_TOKEN`, so the downstream trigger for `release-to-orda.yml` never fires. Confirmed via `gh run list --workflow=release-to-orda.yml`, which returns zero runs.
- Fix: authenticate `semantic-release` with a new `secrets.RELEASE_TOKEN` (a personal access token) instead of `GITHUB_TOKEN`, so the release event cascades correctly.
- Documented the requirement and setup steps in `docs/publish.md` (new "One-time setup: release token" section) and added a troubleshooting entry to `RELEASING.md`.

## ⚠️ Action required before merge

This PR alone does not fix the pipeline — a maintainer with repo admin access needs to:
1. Create a fine-grained PAT (or dedicated bot/service account token) scoped to `RSE-Sheffield/SORT` with **Contents: Read and write**.
2. Add it as repository secret **`RELEASE_TOKEN`** (**Settings → Secrets and variables → Actions**).

Without that secret, `semantic-release` will fail on the next merge to `main` (empty `GITHUB_TOKEN` env var).

## Test plan

- [x] `RELEASE_TOKEN` secret added to the repo before merging
- [ ] After merge, next `feat:`/`fix:` merge to `main` creates a release as before
- [ ] `release-to-orda.yml` run appears in the Actions tab for that release
- [ ] New files appear on the ORDA article and the DOI resolves