### PR TITLE
fix: only show "(deleted user)" for actually anonymised accounts

### DIFF
--- a/home/constants.py
+++ b/home/constants.py
@@ -33,3 +33,6 @@ PERMISSION_CHOICES = [
     (PERMISSION_VIEW, "View Only"),
     (PERMISSION_EDIT, "View and Edit"),
 ]
+
+# Email domain used to mark accounts anonymised for GDPR erasure (see UserService.anonymise)
+DELETED_EMAIL_DOMAIN = "deleted.invalid"

--- a/home/models.py
+++ b/home/models.py
@@ -8,7 +8,7 @@ from django.db.models.signals import pre_delete
 from django.dispatch import receiver
 from django.urls import reverse
 
-from .constants import ROLE_ADMIN, ROLE_PROJECT_MANAGER, ROLES
+from .constants import DELETED_EMAIL_DOMAIN, ROLE_ADMIN, ROLE_PROJECT_MANAGER, ROLES
 
 
 class UserManager(BaseUserManager):
@@ -56,6 +56,14 @@ class User(AbstractBaseUser, PermissionsMixin):
         if not self.first_name and not self.last_name:
             return self.email
         return f"{self.first_name} {self.last_name}"
+
+    @property
+    def is_deleted(self) -> bool:
+        """
+        Whether this account has been anonymised for GDPR erasure (see UserService.anonymise),
+        as opposed to just having a blank name.
+        """
+        return self.email.endswith(f"@{DELETED_EMAIL_DOMAIN}")
 
     @property
     def active_projects(self) -> int:

--- a/home/services/user.py
+++ b/home/services/user.py
@@ -1,5 +1,6 @@
 import uuid
 
+from ..constants import DELETED_EMAIL_DOMAIN
 from ..models import OrganisationMembership, User
 
 
@@ -7,7 +8,7 @@ class UserService:
     def anonymise(self, user: User) -> None:
         user.first_name = "Deleted"
         user.last_name = "User"
-        user.email = f"deleted-{uuid.uuid4().hex}@deleted.invalid"
+        user.email = f"deleted-{uuid.uuid4().hex}@{DELETED_EMAIL_DOMAIN}"
         user.is_active = False
         user.set_unusable_password()
         user.save()

--- a/home/templates/console/users.html
+++ b/home/templates/console/users.html
@@ -30,10 +30,12 @@
                         <tr{% if not user.is_active %} class="text-muted"{% endif %}>
                             <td>
                                 <a href="{% url 'admin_user_detail' user.pk %}">
-                                    {% if user.first_name or user.last_name %}
+                                    {% if user.is_deleted %}
+                                        <em>(deleted user)</em>
+                                    {% elif user.first_name or user.last_name %}
                                         {{ user.first_name }} {{ user.last_name }}
                                     {% else %}
-                                        <em>(deleted user)</em>
+                                        <em>(no name set)</em>
                                     {% endif %}
                                 </a>
                                 {% if not user.is_active %}

--- a/home/tests/test_console_views.py
+++ b/home/tests/test_console_views.py
@@ -104,6 +104,15 @@ class ConsoleViewTestCase(SORT.test.test_case.ViewTestCase):
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertContains(response, "deleted user")
 
+    def test_console_users_blank_name_not_shown_as_deleted(self):
+        """A non-deleted user with a blank name is not mislabelled '(deleted user)' (regression test for #661)."""
+        UserFactory(first_name="", last_name="")
+        self.login_staff()
+        response = self.client.get("/console/users/")
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertNotContains(response, "deleted user")
+        self.assertContains(response, "no name set")
+
     def test_console_surveys_accessible_to_staff(self):
         """Staff users can access the surveys list."""
         self.login_staff()


### PR DESCRIPTION
## Summary
- The staff console user list (`/console/users/`) mislabelled every user with a blank name as `(deleted user)`, regardless of whether the account was actually anonymised.
- Add a `User.is_deleted` property (checks the `@deleted.invalid` email domain set by `UserService.anonymise`) and use it to gate the `(deleted user)` label in `home/templates/console/users.html`.
- Non-deleted users with a genuinely blank name now show `(no name set)` instead of being mislabelled as deleted.
- Extracted the `deleted.invalid` domain into a shared `DELETED_EMAIL_DOMAIN` constant used by both the model and `UserService.anonymise`.

Closes #661

## Test plan
- [x] `python manage.py test home.tests.test_console_views` — all 42 tests pass, including a new regression test (`test_console_users_blank_name_not_shown_as_deleted`) covering the exact bug from #661
- [x] `python manage.py test home.tests --parallel=auto` — full `home` suite passes
- [x] `python manage.py check --fail-level WARNING` — no issues
- [x] `python manage.py makemigrations --check --dry-run` — no model changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)