### PR TITLE
fix: make email lookups case-insensitive (closes #667)

### DIFF
--- a/home/forms/add_existing_member.py
+++ b/home/forms/add_existing_member.py
@@ -28,9 +28,9 @@ class AddExistingMemberForm(forms.Form):
     def clean_email(self):
         email = self.cleaned_data["email"]
 
-        # Check if user exists
+        # Check if user exists (case-insensitive: see issue #667)
         try:
-            user = User.objects.get(email=email)
+            user = User.objects.get(email__iexact=email)
         except User.DoesNotExist:
             raise ValidationError(
                 f"No user with email address '{email}' exists. "

--- a/home/forms/manager_signup.py
+++ b/home/forms/manager_signup.py
@@ -67,7 +67,9 @@ class ManagerSignupForm(UserCreationForm):
         # account is rolled back rather than left orphaned without a membership.
         with transaction.atomic():
             user = super().save(commit=False)
-            user.email = self.email
+            # Bypasses UserManager.create_user, so lowercase explicitly too
+            # (see home/models.py UserManager for why this matters).
+            user.email = self.email.lower()
             user.username = user.email
             if commit:
                 user.save()

--- a/home/forms/user_profile.py
+++ b/home/forms/user_profile.py
@@ -11,11 +11,15 @@ class UserProfileForm(forms.ModelForm):
 
     def clean_email(self):
         email = self.cleaned_data.get("email")
+        if email:
+            # Lowercase to match UserManager's write-side normalization
+            # (see home/models.py) and catch case-variant duplicates below.
+            email = email.lower()
 
         if email == self.instance.email:
             return email
 
-        if User.objects.exclude(pk=self.instance.pk).filter(email=email).exists():
+        if User.objects.exclude(pk=self.instance.pk).filter(email__iexact=email).exists():
             raise forms.ValidationError("This email is already in use.")
         return email
 

--- a/home/migrations/0014_lowercase_existing_emails.py
+++ b/home/migrations/0014_lowercase_existing_emails.py
@@ -1,0 +1,40 @@
+from collections import Counter
+
+from django.db import migrations
+
+
+def lowercase_emails(apps, schema_editor):
+    """
+    Normalize existing user emails to lowercase (see issue #667: mixed-case
+    emails could never log in again once the case-insensitive lookup was
+    added, since exact-match DB queries are case-sensitive on Postgres).
+    """
+    User = apps.get_model("home", "User")
+
+    users = list(User.objects.all())
+    collisions = [
+        email
+        for email, count in Counter(u.email.lower() for u in users).items()
+        if count > 1
+    ]
+    if collisions:
+        raise ValueError(
+            "Cannot lowercase emails: the following addresses collide once "
+            f"lowercased and need manual resolution first: {collisions}"
+        )
+
+    for user in users:
+        lowered = user.email.lower()
+        if lowered != user.email:
+            user.email = lowered
+            user.save(update_fields=["email"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("home", "0013_dataprotectionevent"),
+    ]
+
+    operations = [
+        migrations.RunPython(lowercase_emails, migrations.RunPython.noop),
+    ]

--- a/home/models.py
+++ b/home/models.py
@@ -12,17 +12,33 @@ from .constants import DELETED_EMAIL_DOMAIN, ROLE_ADMIN, ROLE_PROJECT_MANAGER, R
 
 
 class UserManager(BaseUserManager):
+    """
+    A custom manager is required because User is a bespoke AbstractBaseUser
+    subclass with no `username` field (see User.USERNAME_FIELD below) — Django's
+    built-in UserManager assumes a username and can't be reused as-is.
+    """
+
     def create_user(self, first_name, last_name, email, password=None):
         if not email:
             raise ValueError("Email is required")
+        # normalize_email() only lowercases the domain, not the local part, so
+        # the whole address is lowercased explicitly (case #667: an account
+        # created with mixed-case local part could never log in again).
+        # .lower() (not .casefold()) matches what normalize_email() and
+        # allauth's filter_users_by_email() already do on the lookup side.
         user = self.model(
-            email=self.normalize_email(email),
+            email=self.normalize_email(email).lower(),
             first_name=first_name,
             last_name=last_name,
         )
         user.set_password(password)
         user.save(using=self._db)
         return user
+
+    def get_by_natural_key(self, email):
+        # Case-insensitive lookup as a safety net alongside the write-side
+        # normalization above, per Django's own custom-user-model docs.
+        return self.get(email__iexact=email)
 
     def create_superuser(self, email, first_name, last_name, password=None):
         user = self.create_user(
@@ -46,6 +62,8 @@ class User(AbstractBaseUser, PermissionsMixin):
     is_staff = models.BooleanField(default=False)
     date_joined = models.DateTimeField(auto_now_add=True)
 
+    # Email is the unique identifier for this app (there is no username
+    # field), so users log in with email + password.
     USERNAME_FIELD = "email"
     REQUIRED_FIELDS = ["first_name", "last_name"]
 

--- a/home/tests/test_add_existing_member.py
+++ b/home/tests/test_add_existing_member.py
@@ -44,6 +44,20 @@ class AddExistingMemberFormTestCase(TestCase):
             "User should not be marked as duplicate",
         )
 
+    def test_form_valid_with_different_case_email(self):
+        """Emails should match regardless of case (issue #667)"""
+        form = AddExistingMemberForm(
+            data={
+                "email": self.existing_user.email.upper(),
+                "role": ROLE_PROJECT_MANAGER,
+            },
+            organisation=self.organisation,
+            user=self.admin_user,
+        )
+
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+        self.assertEqual(form.get_user(), self.existing_user)
+
     def test_form_invalid_with_nonexistent_user(self):
         """Test that the form is invalid when given a non-existent email"""
         form = AddExistingMemberForm(

--- a/home/tests/test_user_model.py
+++ b/home/tests/test_user_model.py
@@ -1,0 +1,38 @@
+"""
+Test the custom User model / UserManager
+"""
+
+import django.contrib.auth
+import django.test
+
+User = django.contrib.auth.get_user_model()
+
+
+class UserManagerTestCase(django.test.TestCase):
+
+    def test_create_user_lowercases_email(self):
+        """
+        Mixed-case emails should be stored lowercase (issue #667).
+        """
+        user = User.objects.create_user(
+            first_name="Test",
+            last_name="User",
+            email="Mixed.Case@Example.COM",
+            password="password123",
+        )
+        self.assertEqual(user.email, "mixed.case@example.com")
+
+    def test_get_by_natural_key_is_case_insensitive(self):
+        """
+        Looking up a user by email (used during login) should ignore case.
+        """
+        User.objects.create_user(
+            first_name="Test",
+            last_name="User",
+            email="someone@example.com",
+            password="password123",
+        )
+        self.assertEqual(
+            User.objects.get_by_natural_key("SOMEONE@EXAMPLE.COM").email,
+            "someone@example.com",
+        )

--- a/home/tests/test_user_profile_form.py
+++ b/home/tests/test_user_profile_form.py
@@ -1,0 +1,32 @@
+"""
+Test the UserProfileForm
+"""
+
+import django.test
+
+from home.forms.user_profile import UserProfileForm
+from SORT.test.model_factory import UserFactory
+
+
+class UserProfileFormTestCase(django.test.TestCase):
+
+    def setUp(self):
+        self.user = UserFactory()
+        self.other_user = UserFactory()
+
+    def test_rejects_case_variant_duplicate_email(self):
+        """
+        Changing to an email that only differs in case from another user's
+        should be rejected as a duplicate (issue #667).
+        """
+        form = UserProfileForm(
+            data={
+                "email": self.other_user.email.upper(),
+                "first_name": self.user.first_name,
+                "last_name": self.user.last_name,
+            },
+            instance=self.user,
+        )
+
+        self.assertFalse(form.is_valid())
+        self.assertIn("email", form.errors)

--- a/home/tests/test_user_views.py
+++ b/home/tests/test_user_views.py
@@ -5,6 +5,7 @@ Test user profile and authentication views
 from http import HTTPStatus
 
 import SORT.test.test_case
+from SORT.test.model_factory.user.constants import PASSWORD
 
 
 class UserViewTestCase(SORT.test.test_case.ViewTestCase):
@@ -26,6 +27,19 @@ class UserViewTestCase(SORT.test.test_case.ViewTestCase):
                 password=self.user.password,
             ),
             login=False,
+        )
+
+    def test_login_post_case_insensitive_email(self):
+        """
+        Login should succeed even if the email is submitted with different
+        case than stored (issue #667).
+        """
+        self.assertTrue(
+            self.client.login(
+                username=self.user.email.upper(),
+                password=PASSWORD,
+            ),
+            "Authentication with a differently-cased email should succeed",
         )
 
     def test_logout(self):


### PR DESCRIPTION
## Summary
- Emails are lowercased on write (`UserManager.create_user`, manager signup) and matched case-insensitively on read (login, profile edits, adding existing members by email), so an account created with a mixed-case email can still log in.
- `UserManager.get_by_natural_key` now does a case-insensitive lookup as a safety net, per Django's custom-user-model docs.
- Data migration lowercases existing emails, aborting with a clear error if lowercasing would collide two existing accounts (requires manual resolution first).

## Test plan
- [x] `python manage.py test home/tests --parallel=auto --failfast` — all pass
- [x] `python manage.py makemigrations --check --dry-run` — no drift
- [x] `flake8` — clean
- [x] New tests cover: lowercase on create, case-insensitive `get_by_natural_key`, case-insensitive login, case-insensitive "add existing member" lookup, rejecting case-variant duplicate emails on profile edit

Closes #667

🤖 Generated with [Claude Code](https://claude.com/claude-code)