### PR TITLE
fix: correct Figshare API endpoint for ORDA upload

### DIFF
--- a/.github/workflows/release-to-orda.yml
+++ b/.github/workflows/release-to-orda.yml
@@ -25,6 +25,9 @@ jobs:
         uses: figshare/github-upload-action@v1.1
         with:
           FIGSHARE_TOKEN: ${{ secrets.FIGSHARE_TOKEN }}
-          FIGSHARE_ENDPOINT: 'https://orda.shef.ac.uk/v2'
+          FIGSHARE_ENDPOINT: 'https://api.figshare.com/v2'
           FIGSHARE_ARTICLE_ID: ${{ vars.FIGSHARE_ARTICLE_ID }}
           DATA_DIR: data
+
+      - name: Link to ORDA record
+        run: echo "📦 [View this release on ORDA](https://doi.org/10.15131/shef.data.${{ vars.FIGSHARE_ARTICLE_ID }})" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- Fixes #671: the ORDA upload workflow failed on every run with `FigshareAPIError: Not Found` (an HTML 404 page, not a JSON API error).
- Root cause: `FIGSHARE_ENDPOINT` was set to `https://orda.shef.ac.uk/v2`, which is ORDA's web front-end, not an API host — hitting it returns a plain HTML 404 page, matching the error text seen in every failed run.
- Figshare is multi-tenant SaaS: institutional groups like ORDA share the single API host `https://api.figshare.com/v2`; the personal access token determines which institution's articles are reachable. Confirmed against:
  - [RSE-Sheffield/release_to_ORDA](https://github.com/RSE-Sheffield/release_to_ORDA)'s own example workflow, which uses `https://api.figshare.com/v2`.
  - The [figshare/github-upload-action](https://github.com/marketplace/actions/figshare-upload-action) marketplace listing's documented default endpoint.
  - `curl` checks: `orda.shef.ac.uk/v2/...` → `404`, `api.figshare.com/v2/...` → `200`.
- Also added a job summary step linking to the ORDA DOI record (`https://doi.org/10.15131/shef.data.$FIGSHARE_ARTICLE_ID`) so it's easy to find from the workflow run page after a successful upload.

## Test plan
- [ ] Merge and re-run a previously failed `Release to ORDA` workflow run (via Actions → "Re-run jobs") to confirm the "Upload to ORDA via Figshare API" step now succeeds.
- [ ] Confirm the archive files appear on the corresponding ORDA article.
- [ ] Confirm the job summary shows a working link to the ORDA DOI record.