### PR TITLE
fix: bump axios to patch high-severity vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "sort-survey-configurator",
       "version": "0.1.0",
       "dependencies": {
-        "axios": "^1.13.5",
+        "axios": "^1.18.1",
         "chart.js": "^4.4.8",
         "chartjs-plugin-datalabels": "^2.2.0",
         "dompurify": "^3.4.11",
@@ -2734,9 +2734,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
-      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
-    "@types/lodash": "^4.17.16",
     "@eslint/js": "^9.24.0",
     "@semantic-release/github": "^12.0.6",
     "@sveltejs/vite-plugin-svelte": "^5.0.3",
@@ -26,6 +25,7 @@
     "@testing-library/svelte": "^5.2.8",
     "@testing-library/user-event": "^14.6.1",
     "@tsconfig/svelte": "^5.0.4",
+    "@types/lodash": "^4.17.16",
     "@types/lodash-es": "^4.17.12",
     "@types/pell": "^1.0.4",
     "@vitest/coverage-v8": "^3.2.4",
@@ -46,7 +46,7 @@
     "undici": ">=6.27.0"
   },
   "dependencies": {
-    "axios": "^1.13.5",
+    "axios": "^1.18.1",
     "chart.js": "^4.4.8",
     "chartjs-plugin-datalabels": "^2.2.0",
     "dompurify": "^3.4.11",


### PR DESCRIPTION
## Summary
- Bumps `axios` from 1.17.0 to 1.18.1, resolving the Dependabot alerts flagging 10 high-severity advisories against axios <1.18.0 (prototype pollution, `maxBodyLength` bypasses, and DoS via excessive recursion): GHSA-42h9-826w-cgv3, GHSA-xj6q-8x83-jv6g, GHSA-pmv8-rq9r-6j72, GHSA-jqh4-m9w3-8hp9, GHSA-mmx7-hfxf-jppx, GHSA-f4gw-2p7v-4548, GHSA-gcfj-64vw-6mp9, GHSA-hcpx-6fm6-wx23, GHSA-7q8q-rj6j-mhjq, GHSA-mwf2-3pr3-8698
- `package.json`'s axios range moves from `^1.13.5` to `^1.18.1`; lockfile updated accordingly

## Test plan
- [x] `npm audit` no longer reports the axios advisory
- [x] `npm ls axios` shows `1.18.1`
- [x] `npm test` passes (11 files, 16 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)