### PR TITLE
feat: support users belonging to multiple organisations

### DIFF
--- a/SORT/settings.py
+++ b/SORT/settings.py
@@ -110,6 +110,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
+                "home.context_processors.organisation_context",
             ],
         },
     },

--- a/home/context_processors.py
+++ b/home/context_processors.py
@@ -1,0 +1,17 @@
+from .services import organisation_service
+
+
+def organisation_context(request):
+    """
+    Make the user's active organisation and the organisations they can
+    switch between available on every page, for the nav bar's org switcher.
+    """
+    if not getattr(request, "user", None) or not request.user.is_authenticated:
+        return {}
+
+    return {
+        "active_organisation": organisation_service.get_active_organisation(request),
+        "switchable_organisations": organisation_service.get_user_organisations(
+            request.user
+        ),
+    }

--- a/home/mixins.py
+++ b/home/mixins.py
@@ -25,8 +25,8 @@ class MemberManagementRequiredMixin:
     )
 
     def get_member_management_organisation(self, request):
-        # Default: the user's primary organisation.
-        return organisation_service.get_user_organisation(request.user)
+        # Default: the user's active organisation.
+        return organisation_service.get_active_organisation(request)
 
     def dispatch(self, request, *args, **kwargs):
         organisation = self.get_member_management_organisation(request)

--- a/home/services/organisation.py
+++ b/home/services/organisation.py
@@ -7,6 +7,7 @@ from typing import Dict, Optional, Set
 from django.db import transaction
 from django.db.models import Count
 from django.db.models.query import QuerySet
+from django.http import HttpRequest
 
 from ..constants import ROLE_ADMIN, ROLE_PROJECT_MANAGER
 from ..models import (
@@ -73,14 +74,10 @@ class OrganisationService(BasePermissionService):
         role = self.get_user_role(user, organisation)
         return role == ROLE_ADMIN
 
-    def can_create(self, user: User) -> bool:
-        if user.is_superuser:
-            return True
-
-        if OrganisationMembership.objects.filter(user=user).count() < 1:
-            return True
-        else:
-            return False
+    def can_create_organisation(self, user: User) -> bool:
+        """Anyone with a login can create an organisation, including users
+        who already belong to one or more organisations."""
+        return bool(user and user.is_authenticated)
 
     def can_delete(self, user: User, organisation: Organisation) -> bool:
         if user.is_superuser:
@@ -105,6 +102,58 @@ class OrganisationService(BasePermissionService):
             return None
 
         return user.organisation_set.first()
+
+    def get_active_organisation(self, request: HttpRequest) -> Optional[Organisation]:
+        """
+        Resolve the organisation the user is currently "in", for users who may
+        belong to more than one. The choice is sticky across requests via
+        ``request.session["active_organisation_id"]``.
+
+        Fallback chain: no memberships -> None; exactly one membership -> that
+        organisation (so single-org users see no behaviour change); a valid
+        session choice -> that organisation; otherwise (no session choice yet,
+        or the previously active organisation was left/removed) -> the
+        earliest-joined membership, and the session is brought back in sync.
+        """
+        user = request.user
+        if not user or not user.is_authenticated:
+            return None
+
+        memberships = list(
+            OrganisationMembership.objects.filter(user=user)
+            .select_related("organisation")
+            .order_by("joined_at")
+        )
+        if not memberships:
+            request.session.pop("active_organisation_id", None)
+            return None
+
+        if len(memberships) == 1:
+            organisation = memberships[0].organisation
+            request.session["active_organisation_id"] = organisation.id
+            return organisation
+
+        active_id = request.session.get("active_organisation_id")
+        for membership in memberships:
+            if membership.organisation_id == active_id:
+                return membership.organisation
+
+        organisation = memberships[0].organisation
+        request.session["active_organisation_id"] = organisation.id
+        return organisation
+
+    def set_active_organisation(
+        self, request: HttpRequest, organisation: Organisation
+    ) -> None:
+        """
+        Switch the session's active organisation. Caller must have already
+        verified the user is a member of ``organisation``.
+        """
+        request.session["active_organisation_id"] = organisation.id
+
+    def get_user_organisations(self, user: User) -> QuerySet[Organisation]:
+        """All organisations `user` belongs to, for switcher UI."""
+        return Organisation.objects.filter(members=user).order_by("name")
 
     def get_user_organisation_ids(self, user: User) -> Set[int]:
         """Get IDs of organisations user belongs to"""

--- a/home/templates/home/welcome.html
+++ b/home/templates/home/welcome.html
@@ -13,9 +13,9 @@
                             Your name has not been set. Click to <a href="{% url 'profile' %}">update your profile.</a>
                         </p>
                     {% endif %}
-                    {% if user.organisation_set.first %}
+                    {% if active_organisation %}
                         <p class="card-text">You're signed in under <a href="{% url 'myorganisation' %}">
-                            <strong><i class="bx bxs-buildings"></i>&nbsp;{{ user.organisation_set.first.name }}</strong></a>.
+                            <strong><i class="bx bxs-buildings"></i>&nbsp;{{ active_organisation.name }}</strong></a>.
                         </p>
                         {% if projects.count > 0 %}
                             <p class="card-text">

--- a/home/templates/organisation/create.html
+++ b/home/templates/organisation/create.html
@@ -1,40 +1,36 @@
 {% extends "base_manager.html" %}
 {% block content %}
 <div class="container mt-3">
-    {% if request.user.organisation_set.exists %}
-        <meta http-equiv="refresh" content="0;url={% url 'myorganisation' %}">
-    {% else %}
-        <div>
-            <h1>Create an Organisation</h1>
-            <p class="subtitle">Use the form below to create a new organisation.</p>
+    <div>
+        <h1>Create an Organisation</h1>
+        <p class="subtitle">Use the form below to create a new organisation.</p>
+    </div>
+    <div class="card custom-card shadow-sm my-4">
+        <div class="card-body">
+            <form method="post" action="{% url 'organisation_create' %}">
+                {% csrf_token %}
+                {% for field in form %}
+                <div class="mb-3">
+                    <label for="{{ field.id_for_label }}" class="form-label">{{ field.label }}</label>
+                    <input type="{{ field.field.widget.input_type }}"
+                           name="{{ field.name }}"
+                           id="{{ field.id_for_label }}"
+                           class="form-control"
+                           placeholder="Enter {{ field.label|lower }}"
+                           {% if field.value %}value="{{ field.value }}"{% endif %}
+                           {% if field.field.required %}required{% endif %}>
+                    {% if field.help_text %}
+                    <div class="form-text">{{ field.help_text }}</div>
+                    {% endif %}
+                </div>
+                {% endfor %}
+                <div class="text-center">
+                    <button type="submit" class="btn btn-primary" style="background-color: #6933AD; border: none;">
+                        Create Organisation
+                    </button>
+                </div>
+            </form>
         </div>
-        <div class="card custom-card shadow-sm my-4">
-            <div class="card-body">
-                <form method="post" action="{% url 'organisation_create' %}">
-                    {% csrf_token %}
-                    {% for field in form %}
-                    <div class="mb-3">
-                        <label for="{{ field.id_for_label }}" class="form-label">{{ field.label }}</label>
-                        <input type="{{ field.field.widget.input_type }}"
-                               name="{{ field.name }}"
-                               id="{{ field.id_for_label }}"
-                               class="form-control"
-                               placeholder="Enter {{ field.label|lower }}"
-                               {% if field.value %}value="{{ field.value }}"{% endif %}
-                               {% if field.field.required %}required{% endif %}>
-                        {% if field.help_text %}
-                        <div class="form-text">{{ field.help_text }}</div>
-                        {% endif %}
-                    </div>
-                    {% endfor %}
-                    <div class="text-center">
-                        <button type="submit" class="btn btn-primary" style="background-color: #6933AD; border: none;">
-                            Create Organisation
-                        </button>
-                    </div>
-                </form>
-            </div>
-        </div>
-    {% endif %}
+    </div>
 </div>
 {% endblock %}

--- a/home/tests/test_organisation_service.py
+++ b/home/tests/test_organisation_service.py
@@ -3,13 +3,19 @@ Test the organisation service
 """
 
 from django.contrib.auth import get_user_model
+from django.contrib.sessions.backends.db import SessionStore
 from django.core.exceptions import PermissionDenied
+from django.test import RequestFactory
 
 import SORT.test.test_case
 from home.constants import ROLE_ADMIN, ROLES
 from home.models import Organisation, OrganisationMembership
 from home.services import organisation_service
-from SORT.test.model_factory import OrganisationFactory, UserFactory
+from SORT.test.model_factory import (
+    OrganisationFactory,
+    OrganisationMembershipFactory,
+    UserFactory,
+)
 
 User = get_user_model()
 
@@ -23,6 +29,13 @@ class OrganisationServiceTestCase(SORT.test.test_case.ServiceTestCase):
         self.manager: User = self.organisation.members.first()
         self.manager.first_name = "Manager"
         self.another_user = UserFactory()
+        self.factory = RequestFactory()
+
+    def _make_request(self, user):
+        request = self.factory.get("/")
+        request.user = user
+        request.session = SessionStore()
+        return request
 
     def test_create_organisation(self):
         """
@@ -41,6 +54,24 @@ class OrganisationServiceTestCase(SORT.test.test_case.ServiceTestCase):
         self.assertTrue(
             Organisation.objects.filter(name=name).exists(),
             "Organisation doesn't exist",
+        )
+
+    def test_create_organisation_when_already_a_member(self):
+        """
+        A user who already belongs to an organisation can still create
+        (and join) another one (issue #675).
+        """
+        self.assertTrue(self.service.can_create_organisation(self.manager))
+
+        organisation = self.service.create_organisation(
+            user=self.manager,
+            name="A second organisation",
+            description="",
+        )
+
+        self.assertEqual(
+            {self.organisation.pk, organisation.pk},
+            self.service.get_user_organisation_ids(self.manager),
         )
 
     def test_create_organisation_as_superuser(self):
@@ -81,7 +112,7 @@ class OrganisationServiceTestCase(SORT.test.test_case.ServiceTestCase):
         self.service.can_edit(user=user, organisation=organisation)
         self.service.can_delete(user=user, organisation=organisation)
         self.service.can_manage_members(user=user, organisation=organisation)
-        self.service.can_create(user=user)
+        self.service.can_create_organisation(user=user)
         self.service.get_user_organisation(user=user)
 
         # Check member exists in that organisation
@@ -204,3 +235,120 @@ class OrganisationServiceTestCase(SORT.test.test_case.ServiceTestCase):
         # See if a random user can view the membership
         with self.assertRaises(PermissionDenied):
             self.service.get_organisation_members(self.another_user, self.organisation)
+
+
+class ActiveOrganisationTestCase(SORT.test.test_case.ServiceTestCase):
+    """Tests for the session-backed "active organisation" concept (#675)."""
+
+    def setUp(self):
+        super().setUp()
+        self.service = organisation_service
+        self.factory = RequestFactory()
+
+    def _make_request(self, user):
+        request = self.factory.get("/")
+        request.user = user
+        request.session = SessionStore()
+        return request
+
+    def test_anonymous_user_has_no_active_organisation(self):
+        from django.contrib.auth.models import AnonymousUser
+
+        request = self._make_request(AnonymousUser())
+        self.assertIsNone(self.service.get_active_organisation(request))
+
+    def test_user_with_no_organisations_has_no_active_organisation(self):
+        request = self._make_request(self.user)
+        request.session["active_organisation_id"] = 999
+        self.assertIsNone(self.service.get_active_organisation(request))
+        self.assertNotIn("active_organisation_id", request.session)
+
+    def test_user_with_one_organisation_is_auto_selected(self):
+        membership = OrganisationMembershipFactory(
+            user=self.user, organisation=OrganisationFactory()
+        )
+        request = self._make_request(self.user)
+
+        organisation = self.service.get_active_organisation(request)
+
+        self.assertEqual(membership.organisation, organisation)
+        self.assertEqual(
+            membership.organisation.id, request.session["active_organisation_id"]
+        )
+
+    def test_user_with_multiple_organisations_defaults_to_earliest_joined(self):
+        first = OrganisationMembershipFactory(
+            user=self.user, organisation=OrganisationFactory()
+        )
+        second = OrganisationMembershipFactory(
+            user=self.user, organisation=OrganisationFactory()
+        )
+        request = self._make_request(self.user)
+
+        organisation = self.service.get_active_organisation(request)
+
+        self.assertEqual(first.organisation, organisation)
+        self.assertEqual(
+            first.organisation.id, request.session["active_organisation_id"]
+        )
+        self.assertNotEqual(second.organisation, organisation)
+
+    def test_active_organisation_choice_persists_via_session(self):
+        OrganisationMembershipFactory(user=self.user, organisation=OrganisationFactory())
+        second = OrganisationMembershipFactory(
+            user=self.user, organisation=OrganisationFactory()
+        )
+        request = self._make_request(self.user)
+        request.session["active_organisation_id"] = second.organisation.id
+
+        organisation = self.service.get_active_organisation(request)
+
+        self.assertEqual(second.organisation, organisation)
+
+    def test_stale_active_organisation_falls_back_to_valid_membership(self):
+        first = OrganisationMembershipFactory(
+            user=self.user, organisation=OrganisationFactory()
+        )
+        removed = OrganisationMembershipFactory(
+            user=self.user, organisation=OrganisationFactory()
+        )
+        request = self._make_request(self.user)
+        request.session["active_organisation_id"] = removed.organisation.id
+
+        # The user has since been removed from that organisation.
+        removed.delete()
+
+        organisation = self.service.get_active_organisation(request)
+
+        self.assertEqual(first.organisation, organisation)
+        self.assertEqual(
+            first.organisation.id, request.session["active_organisation_id"]
+        )
+
+    def test_set_active_organisation(self):
+        OrganisationMembershipFactory(user=self.user, organisation=OrganisationFactory())
+        second = OrganisationMembershipFactory(
+            user=self.user, organisation=OrganisationFactory()
+        )
+        request = self._make_request(self.user)
+
+        self.service.set_active_organisation(request, second.organisation)
+
+        self.assertEqual(
+            second.organisation, self.service.get_active_organisation(request)
+        )
+
+    def test_get_user_organisations(self):
+        first = OrganisationMembershipFactory(
+            user=self.user, organisation=OrganisationFactory()
+        )
+        second = OrganisationMembershipFactory(
+            user=self.user, organisation=OrganisationFactory()
+        )
+
+        organisations = self.service.get_user_organisations(self.user)
+
+        self.assertEqual(
+            {first.organisation.pk, second.organisation.pk},
+            set(organisations.values_list("pk", flat=True)),
+        )

--- a/home/tests/test_organisation_views.py
+++ b/home/tests/test_organisation_views.py
@@ -8,9 +8,9 @@ import django.contrib.auth
 import django.test
 import django.urls
 
-from home.constants import ROLE_PROJECT_MANAGER
+from home.constants import ROLE_ADMIN, ROLE_PROJECT_MANAGER
 from home.models import Organisation, OrganisationMembership
-from SORT.test.model_factory import OrganisationFactory
+from SORT.test.model_factory import OrganisationFactory, OrganisationMembershipFactory
 from SORT.test.model_factory.user.constants import PASSWORD
 from SORT.test.test_case import ViewTestCase
 
@@ -122,5 +122,99 @@ class OrganisationViewTestCase(ViewTestCase):
         self.organisation.refresh_from_db()
         self.assertEqual(self.organisation.name, original_name)
 
+    def test_organisation_create_when_already_a_member(self):
+        """
+        A user can create a second organisation even though they already
+        belong to one (issue #675), and it becomes their active organisation.
+        """
+        OrganisationMembershipFactory(
+            user=self.user, organisation=self.organisation, role=ROLE_ADMIN
+        )
+        self.login()
+
+        response = self.client.post(
+            path=django.urls.reverse("organisation_create"),
+            data=dict(name="My second org", description=""),
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
+        new_organisation = Organisation.objects.get(name="My second org")
+
+        # The newly created organisation is now active.
+        dashboard_response = self.client.get(django.urls.reverse("myorganisation"))
+        self.assertContains(dashboard_response, new_organisation.name)
+
     def test_organisation_view(self):
         self.skipTest("Not yet implemented")
+
+
+class SetActiveOrganisationViewTestCase(ViewTestCase):
+    """Tests for the org-switcher view (issue #675)."""
+
+    def setUp(self):
+        super().setUp()
+        self.first_organisation = OrganisationFactory()
+        self.second_organisation = OrganisationFactory()
+        OrganisationMembershipFactory(
+            user=self.user, organisation=self.first_organisation, role=ROLE_ADMIN
+        )
+        OrganisationMembershipFactory(
+            user=self.user, organisation=self.second_organisation, role=ROLE_ADMIN
+        )
+
+    def test_switch_to_a_member_organisation(self):
+        self.login()
+
+        response = self.client.post(
+            django.urls.reverse("organisation_switch"),
+            data={"organisation_id": self.second_organisation.pk},
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
+
+        dashboard_response = self.client.get(django.urls.reverse("myorganisation"))
+        self.assertContains(
+            dashboard_response, f"<h1>{self.second_organisation.name}</h1>"
+        )
+        self.assertNotContains(
+            dashboard_response, f"<h1>{self.first_organisation.name}</h1>"
+        )
+
+    def test_cannot_switch_to_an_organisation_not_a_member_of(self):
+        other_organisation = OrganisationFactory()
+        self.login()
+
+        response = self.client.post(
+            django.urls.reverse("organisation_switch"),
+            data={"organisation_id": other_organisation.pk},
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
+
+    def test_switch_requires_login(self):
+        response = self.client.post(
+            django.urls.reverse("organisation_switch"),
+            data={"organisation_id": self.first_organisation.pk},
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
+        self.assertIn(django.urls.reverse("login"), response.url)
+
+    def test_switcher_not_shown_for_single_organisation_user(self):
+        OrganisationMembership.objects.filter(
+            user=self.user, organisation=self.second_organisation
+        ).delete()
+        self.login()
+
+        response = self.client.get(django.urls.reverse("myorganisation"))
+
+        self.assertNotContains(response, "orgSwitcherDropdown")
+
+    def test_switcher_shown_for_multi_organisation_user(self):
+        self.login()
+
+        response = self.client.get(django.urls.reverse("myorganisation"))
+
+        self.assertContains(response, "orgSwitcherDropdown")
+        self.assertContains(response, self.first_organisation.name)
+        self.assertContains(response, self.second_organisation.name)

--- a/home/urls.py
+++ b/home/urls.py
@@ -53,6 +53,11 @@ urlpatterns = [
     ),
     path("myorganisation/", views.MyOrganisationView.as_view(), name="myorganisation"),
     path(
+        "myorganisation/switch/",
+        views.SetActiveOrganisationView.as_view(),
+        name="organisation_switch",
+    ),
+    path(
         "myorganisation/edit/",
         views.OrganisationEditView.as_view(),
         name="organisation_edit",

--- a/home/views/__init__.py
+++ b/home/views/__init__.py
@@ -28,6 +28,7 @@ from .organisation import (
     OrganisationEditView,
     OrganisationMembershipDeleteView,
     OrganisationMembershipListView,
+    SetActiveOrganisationView,
 )
 from .console import (
     ConsoleDataProtectionLogView,
@@ -77,6 +78,7 @@ __all__ = [
     "OrganisationEditView",
     "OrganisationMembershipDeleteView",
     "OrganisationMembershipListView",
+    "SetActiveOrganisationView",
     "ProjectCreateView",
     "ProjectDeleteView",
     "ProjectEditView",

--- a/home/views/organisation.py
+++ b/home/views/organisation.py
@@ -7,8 +7,10 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.messages.views import SuccessMessageMixin
 from django.core.exceptions import PermissionDenied
 from django.db.models import Q
-from django.shortcuts import redirect
+from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse, reverse_lazy
+from django.utils.http import url_has_allowed_host_and_scheme
+from django.views import View
 from django.views.generic import (
     CreateView,
     DeleteView,
@@ -35,7 +37,7 @@ class MyOrganisationView(LoginRequiredMixin, OrganisationRequiredMixin, ListView
 
     def setup(self, request, *args, **kwargs):
         super().setup(request, *args, **kwargs)
-        self.organisation = organisation_service.get_user_organisation(request.user)
+        self.organisation = organisation_service.get_active_organisation(request)
 
         if not self.organisation:
             messages.error(request, "You are not a member of any organisation.")
@@ -93,6 +95,7 @@ class OrganisationCreateView(LoginRequiredMixin, CreateView):
                 name=form.cleaned_data["name"],
                 description=form.cleaned_data["description"],
             )
+            organisation_service.set_active_organisation(self.request, organisation)
             self.object = organisation
             return redirect(self.get_success_url())
         except PermissionDenied:
@@ -100,6 +103,29 @@ class OrganisationCreateView(LoginRequiredMixin, CreateView):
                 self.request, "You don't have permission to create organisations."
             )
             return redirect("dashboard")
+
+
+class SetActiveOrganisationView(LoginRequiredMixin, View):
+    """
+    Switch the session's active organisation to one the user is a member
+    of (issue #675). POST-only, since this changes state.
+    """
+
+    def post(self, request, *args, **kwargs):
+        organisation = get_object_or_404(
+            Organisation,
+            pk=request.POST.get("organisation_id"),
+            members=request.user,
+        )
+        organisation_service.set_active_organisation(request, organisation)
+        messages.success(request, f"Switched to {organisation.name}.")
+
+        next_url = request.POST.get("next") or reverse("myorganisation")
+        if not url_has_allowed_host_and_scheme(
+            next_url, allowed_hosts={request.get_host()}
+        ):
+            next_url = reverse("myorganisation")
+        return redirect(next_url)
 
 
 class OrganisationEditView(LoginRequiredMixin, OrganisationRequiredMixin, UpdateView):
@@ -117,10 +143,11 @@ class OrganisationEditView(LoginRequiredMixin, OrganisationRequiredMixin, Update
     context_object_name = "organisation"
 
     def dispatch(self, request, *args, **kwargs):
-        # Resolve the user's organisation and check edit permission up front so
-        # that non-admins are redirected cleanly rather than shown the form.
+        # Resolve the user's active organisation and check edit permission up
+        # front so that non-admins are redirected cleanly rather than shown
+        # the form.
         if request.user.is_authenticated:
-            organisation = organisation_service.get_user_organisation(request.user)
+            organisation = organisation_service.get_active_organisation(request)
             if organisation and not organisation_service.can_edit(
                 request.user, organisation
             ):
@@ -131,7 +158,7 @@ class OrganisationEditView(LoginRequiredMixin, OrganisationRequiredMixin, Update
         return super().dispatch(request, *args, **kwargs)
 
     def get_object(self, queryset=None):
-        return organisation_service.get_user_organisation(self.request.user)
+        return organisation_service.get_active_organisation(self.request)
 
     def get_success_url(self):
         return reverse("myorganisation")
@@ -159,7 +186,7 @@ class OrganisationMembershipListView(
 
     @property
     def organisation(self) -> Organisation:
-        return organisation_service.get_user_organisation(self.request.user)
+        return organisation_service.get_active_organisation(self.request)
 
     def get_queryset(self):
         queryset = super().get_queryset()
@@ -198,7 +225,7 @@ class MyOrganisationInviteView(
 
     def setup(self, request, *args, **kwargs):
         super().setup(request, *args, **kwargs)
-        self.organisation = organisation_service.get_user_organisation(request.user)
+        self.organisation = organisation_service.get_active_organisation(request)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -379,7 +406,7 @@ class DataSharingAgreementView(LoginRequiredMixin, DetailView):
         Get the organisation and verify user has access to it.
         """
 
-        organisation = self.request.user.organisation_set.first()
+        organisation = organisation_service.get_active_organisation(self.request)
 
         # Verify user is a member of this organisation
         if not organisation_service.can_view(self.request.user, organisation):

--- a/static/templates/base_manager.html
+++ b/static/templates/base_manager.html
@@ -61,6 +61,29 @@
                         {% endif %}
                     </ol>
                     <ul class="navbar-nav">
+                        {% if user.is_authenticated and switchable_organisations|length > 1 %}
+                            <li class="nav-item dropdown">
+                                <a class="nav-link dropdown-toggle" href="#" id="orgSwitcherDropdown"
+                                   role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                                    <i class="bx bxs-buildings"></i> {{ active_organisation.name }}
+                                </a>
+                                <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="orgSwitcherDropdown">
+                                    {% for org in switchable_organisations %}
+                                        <li>
+                                            <form method="POST" action="{% url 'organisation_switch' %}">
+                                                {% csrf_token %}
+                                                <input type="hidden" name="organisation_id" value="{{ org.id }}">
+                                                <input type="hidden" name="next" value="{{ request.path }}">
+                                                <button type="submit"
+                                                        class="dropdown-item{% if org.id == active_organisation.id %} active{% endif %}">
+                                                    {{ org.name }}
+                                                </button>
+                                            </form>
+                                        </li>
+                                    {% endfor %}
+                                </ul>
+                            </li>
+                        {% endif %}
                         {% if user.is_authenticated %}
                             <li class="nav-item">
                                 <form id="logout-form"


### PR DESCRIPTION
## Summary
- Users can now create an organisation even if they already belong to one or more (previously `can_create` blocked anyone with an existing membership).
- Adds a session-backed "active organisation" concept (`get_active_organisation`/`set_active_organisation`) so multi-org users have a consistent org context across requests, replacing the old `organisation_set.first()` lookups throughout org views, mixins, and templates.
- Adds `SetActiveOrganisationView` (`/myorganisation/switch/`) plus a nav-bar dropdown switcher (shown when a user belongs to more than one organisation), with open-redirect protection via `url_has_allowed_host_and_scheme`.
- New `home.context_processors.organisation_context` exposes `active_organisation` and `switchable_organisations` to all templates.
- Simplifies the organisation create template (no more silent redirect for existing org members).

## Screenshots

Organisation switcher
<img width="392" height="289" alt="image" src="https://github.com/user-attachments/assets/85d4ebbd-bf1f-461d-bb98-6b237fe38659" />

Info alert after switching
<img width="1452" height="420" alt="image" src="https://github.com/user-attachments/assets/0aa98c92-846b-4128-a3a9-37bf45d4e9c0" />

Closes #675.

## Test plan
- [x] `python manage.py test home.tests.test_organisation_service home.tests.test_organisation_views --parallel=auto --failfast` — passing
- [x] `python manage.py test home.tests --parallel=auto` — 127 tests, passing
- [x] Manual check: log in as a user in two organisations, confirm switcher appears and preserves selection across pages