### PR TITLE
fix: don't silently switch active organisation when creating a new one

### DIFF
--- a/home/tests/test_organisation_views.py
+++ b/home/tests/test_organisation_views.py
@@ -5,6 +5,7 @@ Unit tests for organisation views
 from http import HTTPStatus
 
 import django.contrib.auth
+import django.contrib.messages
 import django.test
 import django.urls
 
@@ -125,7 +126,10 @@ class OrganisationViewTestCase(ViewTestCase):
     def test_organisation_create_when_already_a_member(self):
         """
         A user can create a second organisation even though they already
-        belong to one (issue #675), and it becomes their active organisation.
+        belong to one (issue #675), but their active organisation is not
+        silently switched to the new one (issue #682) - their existing
+        organisation stays active, and they're told how to switch to the
+        new one.
         """
         OrganisationMembershipFactory(
             user=self.user, organisation=self.organisation, role=ROLE_ADMIN
@@ -138,9 +142,34 @@ class OrganisationViewTestCase(ViewTestCase):
         )
 
         self.assertEqual(response.status_code, HTTPStatus.FOUND)
-        new_organisation = Organisation.objects.get(name="My second org")
+        self.assertTrue(Organisation.objects.filter(name="My second org").exists())
 
-        # The newly created organisation is now active.
+        messages = list(django.contrib.messages.get_messages(response.wsgi_request))
+        self.assertTrue(
+            any("switcher" in str(message) for message in messages),
+            "Expected a message explaining how to switch to the new organisation",
+        )
+
+        # The user's original organisation is still active - not silently
+        # switched to the newly created one.
+        dashboard_response = self.client.get(django.urls.reverse("myorganisation"))
+        self.assertContains(dashboard_response, self.organisation.name)
+
+    def test_organisation_create_when_not_already_a_member(self):
+        """
+        A user with no existing organisation has their newly created
+        organisation set as active, as before (issue #682).
+        """
+        self.login()
+
+        response = self.client.post(
+            path=django.urls.reverse("organisation_create"),
+            data=dict(name="My first org", description=""),
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
+        new_organisation = Organisation.objects.get(name="My first org")
+
         dashboard_response = self.client.get(django.urls.reverse("myorganisation"))
         self.assertContains(dashboard_response, new_organisation.name)
 

--- a/home/views/organisation.py
+++ b/home/views/organisation.py
@@ -89,13 +89,26 @@ class OrganisationCreateView(LoginRequiredMixin, CreateView):
         return reverse_lazy("myorganisation")
 
     def form_valid(self, form):
+        had_organisation = (
+            organisation_service.get_active_organisation(self.request) is not None
+        )
         try:
             organisation = organisation_service.create_organisation(
                 user=self.request.user,
                 name=form.cleaned_data["name"],
                 description=form.cleaned_data["description"],
             )
-            organisation_service.set_active_organisation(self.request, organisation)
+            if had_organisation:
+                messages.success(
+                    self.request,
+                    f"{organisation.name} created. Use the organisation switcher "
+                    "in the navigation menu to switch to it.",
+                )
+            else:
+                organisation_service.set_active_organisation(
+                    self.request, organisation
+                )
+                messages.success(self.request, f"{organisation.name} created.")
             self.object = organisation
             return redirect(self.get_success_url())
         except PermissionDenied:


### PR DESCRIPTION
## Summary
- Creating a new organisation while already belonging to one no longer flips the user's active organisation — their existing organisation stays active and a message tells them to use the organisation switcher to reach the new one.
- Users with no existing organisation still get the newly created one set active automatically, as before.

This addresses the first bug in #682 (the active-org auto-switch hiding existing memberships). The related `.first()` inviter-org lookup bug described in the same issue is a separate follow-up and is not covered here.

## Test plan
- [x] `python manage.py test home.tests.test_organisation_views --parallel=auto --failfast` passes, including new/updated tests covering both the already-a-member and not-a-member cases.